### PR TITLE
feat: add a rest catalog example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,6 +2154,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "iceberg-catalog-rest"
+version = "0.4.0"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=15a4686b911d8a0847347342eda4e77f9057d29b#15a4686b911d8a0847347342eda4e77f9057d29b"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "http",
+ "iceberg",
+ "itertools 0.13.0",
+ "log",
+ "reqwest",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tokio",
+ "typed-builder 0.20.1",
+ "uuid",
+]
+
+[[package]]
 name = "iceberg-compact-core"
 version = "0.1.0"
 dependencies = [
@@ -2189,7 +2209,6 @@ dependencies = [
  "iceberg",
  "iceberg-catalog-memory",
  "iceberg-compact-core",
- "parquet",
  "tempfile",
  "tokio",
 ]
@@ -3618,6 +3637,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rest-catalog-example"
+version = "0.1.0"
+dependencies = [
+ "iceberg",
+ "iceberg-catalog-rest",
+ "iceberg-compact-core",
+ "tokio",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4647,9 +4676,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["core", "examples/memory-catalog"]
+members = ["core", "examples/memory-catalog", "examples/rest-catalog"]
 
 [workspace.dependencies]
 # Async runtime and utilities
@@ -18,6 +18,7 @@ iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1
     "storage-gcs",
 ] }
 iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "15a4686b911d8a0847347342eda4e77f9057d29b" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "15a4686b911d8a0847347342eda4e77f9057d29b" }
 iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "15a4686b911d8a0847347342eda4e77f9057d29b" }
 parquet = { version = "54", features = ["async"] }
 

--- a/examples/memory-catalog/src/main.rs
+++ b/examples/memory-catalog/src/main.rs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 iceberg-compaction
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use tempfile::TempDir;

--- a/examples/memory-catalog/src/main.rs
+++ b/examples/memory-catalog/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let catalog = Arc::new(MemoryCatalog::new(file_io, Some(warehouse_location)));
 
     // 3. Create namespace and table
-    let namespace_ident = NamespaceIdent::new("warehouse".into());
+    let namespace_ident = NamespaceIdent::new("my_namespace".into());
     catalog
         .create_namespace(&namespace_ident, HashMap::new())
         .await?;

--- a/examples/rest-catalog/Cargo.toml
+++ b/examples/rest-catalog/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
-name = "iceberg-compact-example"
+name = "rest-catalog-example"
 version = "0.1.0"
 edition = "2024"
 
 [dependencies]
 iceberg = { workspace = true }
-iceberg-catalog-memory = { workspace = true }
+iceberg-catalog-rest = { workspace = true }
 iceberg-compact-core = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/examples/rest-catalog/src/main.rs
+++ b/examples/rest-catalog/src/main.rs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 iceberg-compaction
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/examples/rest-catalog/src/main.rs
+++ b/examples/rest-catalog/src/main.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use iceberg::io::{
+    S3_ACCESS_KEY_ID, S3_DISABLE_CONFIG_LOAD, S3_ENDPOINT, S3_REGION, S3_SECRET_ACCESS_KEY,
+};
+use iceberg::{Catalog, NamespaceIdent, TableIdent};
+
+use iceberg_compact_core::compaction::CompactionBuilder;
+use iceberg_compact_core::config::CompactionConfigBuilder;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Configure the warehouse and catalog
+    let mut iceberg_configs = HashMap::new();
+
+    let load_credentials_from_env = true;
+    if load_credentials_from_env {
+        iceberg_configs.insert(S3_DISABLE_CONFIG_LOAD.to_owned(), "false".to_owned());
+    } else {
+        iceberg_configs.insert(S3_DISABLE_CONFIG_LOAD.to_owned(), "true".to_owned());
+        iceberg_configs.insert(S3_REGION.to_owned(), "us-east-1".to_owned());
+        iceberg_configs.insert(S3_ENDPOINT.to_owned(), "http://localhost:9000".to_owned());
+        iceberg_configs.insert(S3_ACCESS_KEY_ID.to_owned(), "xxxxxxx".to_owned());
+        iceberg_configs.insert(S3_SECRET_ACCESS_KEY.to_owned(), "yyyyyyy".to_owned());
+    }
+
+    // Optional configurations for authentication
+    // iceberg_configs.insert("credential".to_owned(), "your-catalog-credential".to_owned());
+    // iceberg_configs.insert("token".to_owned(), "your-catalog-token".to_owned());
+    // iceberg_configs.insert("oauth2-server-uri".to_owned(), "http://localhost:8080/oauth2".to_owned());
+    // iceberg_configs.insert("scope".to_owned(), "your-scope".to_owned());
+
+    let config_builder = iceberg_catalog_rest::RestCatalogConfig::builder()
+        .uri("http://localhost:8080/your/catalog/uri".to_string())
+        .warehouse("your-warehouse-location".to_string())
+        .props(iceberg_configs);
+
+    // 2. Create the catalog
+    let catalog = Arc::new(iceberg_catalog_rest::RestCatalog::new(
+        config_builder.build(),
+    ));
+
+    let namespace_ident = NamespaceIdent::new("my_namespace".into());
+    let table_ident = TableIdent::new(namespace_ident, "my_table".into());
+
+    // 3. Configure compaction settings
+    let compaction_config = CompactionConfigBuilder::default().build()?;
+    let compaction = CompactionBuilder::new()
+        .with_catalog(catalog.clone())
+        .with_table_ident(table_ident.clone())
+        .with_config(Arc::new(compaction_config))
+        .with_catalog_name("my_rest_catalog".to_string())
+        .build()
+        .await?;
+
+    // 4. Perform the compaction
+    println!("Starting compaction for table: {}", table_ident);
+    let stats = compaction.compact().await?;
+
+    // 5. Display compaction results
+    println!("Compaction completed successfully!");
+    println!("  - Rewritten files: {}", stats.rewritten_files_count);
+    println!("  - Added files: {}", stats.added_files_count);
+    println!("  - Rewritten bytes: {}", stats.rewritten_bytes);
+    println!("  - Failed files: {}", stats.failed_data_files_count);
+
+    // optional you can check the table after compaction
+    let _table = catalog.load_table(&table_ident).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
This pull request introduces a new example for a REST-based catalog implementation and updates related configurations across the project. It also includes minor adjustments to the memory catalog example for consistency. The most significant changes involve adding the new `rest-catalog` example, updating workspace members, and configuring dependencies.

### New REST-based catalog example:

* Added a new example `rest-catalog` to demonstrate using a REST-based catalog with Iceberg. Includes configurations for warehouse setup, authentication, and table compaction. (`examples/rest-catalog/Cargo.toml`, `examples/rest-catalog/src/main.rs`) [[1]](diffhunk://#diff-0f25db688cd8726d500c02a0d48804ceec06f536e4f9fe8db0a40bda48c41a69R1-R10) [[2]](diffhunk://#diff-e855f195eb515ce07e65516195419f6ff03d0064bde7eaa9d2735da847b48303R1-R72)

### Workspace and dependencies updates:

* Updated `Cargo.toml` to include `examples/rest-catalog` as a workspace member and added `iceberg-catalog-rest` as a dependency. (`Cargo.toml`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R21)

### Adjustments to memory catalog example:

* Removed the `parquet` dependency from `examples/memory-catalog/Cargo.toml`. (`examples/memory-catalog/Cargo.toml`)
* Changed the namespace identifier in `examples/memory-catalog/src/main.rs` from `"warehouse"` to `"my_namespace"` for consistency with the new example. (`examples/memory-catalog/src/main.rs`)