### PR TITLE
feat(executor): fix re partition

### DIFF
--- a/core/src/compaction/mod.rs
+++ b/core/src/compaction/mod.rs
@@ -19,14 +19,14 @@ use iceberg::{Catalog, ErrorKind, TableIdent};
 use mixtrics::metrics::BoxedRegistry;
 use mixtrics::registry::noop::NoopMetricsRegistry;
 
+use crate::CompactionError;
+use crate::Result;
 use crate::common::Metrics;
 use crate::compaction::validator::CompactionValidator;
 use crate::executor::{
-    create_compaction_executor, ExecutorType, InputFileScanTasks, RewriteFilesRequest,
-    RewriteFilesResponse, RewriteFilesStat,
+    ExecutorType, InputFileScanTasks, RewriteFilesRequest, RewriteFilesResponse, RewriteFilesStat,
+    create_compaction_executor,
 };
-use crate::CompactionError;
-use crate::Result;
 use crate::{CompactionConfig, CompactionExecutor};
 use futures_async_stream::for_await;
 use iceberg::scan::FileScanTask;
@@ -628,17 +628,17 @@ mod tests {
         EqualityDeleteFileWriterBuilder, EqualityDeleteWriterConfig,
     };
     use iceberg::writer::base_writer::sort_position_delete_writer::{
-        SortPositionDeleteWriterBuilder, POSITION_DELETE_SCHEMA,
+        POSITION_DELETE_SCHEMA, SortPositionDeleteWriterBuilder,
     };
+    use iceberg::writer::file_writer::ParquetWriterBuilder;
     use iceberg::writer::file_writer::location_generator::{
         DefaultFileNameGenerator, DefaultLocationGenerator,
     };
-    use iceberg::writer::file_writer::ParquetWriterBuilder;
     use iceberg::writer::function_writer::equality_delta_writer::{
-        EqualityDeltaWriterBuilder, DELETE_OP, INSERT_OP,
+        DELETE_OP, EqualityDeltaWriterBuilder, INSERT_OP,
     };
     use iceberg::writer::{
-        base_writer::data_file_writer::DataFileWriterBuilder, IcebergWriter, IcebergWriterBuilder,
+        IcebergWriter, IcebergWriterBuilder, base_writer::data_file_writer::DataFileWriterBuilder,
     };
     use iceberg::{Catalog, NamespaceIdent, TableCreation, TableIdent};
     use iceberg_catalog_memory::MemoryCatalog;

--- a/core/src/compaction/validator.rs
+++ b/core/src/compaction/validator.rs
@@ -27,10 +27,10 @@ use iceberg::table::Table;
 
 use crate::config::CompactionConfigBuilder;
 use crate::error::Result;
+use crate::executor::InputFileScanTasks;
 use crate::executor::datafusion::datafusion_processor::{
     DataFusionTaskContext, DatafusionProcessor,
 };
-use crate::executor::InputFileScanTasks;
 use crate::{CompactionConfig, CompactionError};
 
 pub struct CompactionValidator {
@@ -94,8 +94,8 @@ impl CompactionValidator {
 
         let validator_config = Arc::new(
             CompactionConfigBuilder::default()
-                .batch_parallelism(config.batch_parallelism)
-                .target_partitions(config.target_partitions)
+                .executor_parallelism(config.executor_parallelism)
+                .output_parallelism(config.output_parallelism)
                 .build()
                 .map_err(|e| CompactionError::Config(e.to_string()))?,
         );

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -19,8 +19,8 @@ use parquet::{basic::Compression, file::properties::WriterProperties};
 use serde::Deserialize;
 
 const DEFAULT_PREFIX: &str = "iceberg-compact";
-const DEFAULT_BATCH_PARALLELISM: usize = 4;
-const DEFAULT_TARGET_PARTITIONS: usize = 4;
+const DEFAULT_EXECUTOR_PARALLELISM: usize = 4;
+const DEFAULT_OUTPUT_PARALLELISM: usize = 4;
 const DEFAULT_TARGET_FILE_SIZE: u64 = 1024 * 1024 * 1024; // 1 GB
 const DEFAULT_VALIDATE_COMPACTION: bool = false;
 const DEFAULT_MAX_RECORD_BATCH_ROWS: usize = 1024;
@@ -35,10 +35,12 @@ fn default_writer_properties() -> WriterProperties {
 
 #[derive(Builder, Debug, Deserialize, Default, Clone)]
 pub struct CompactionConfig {
-    #[builder(default = "DEFAULT_BATCH_PARALLELISM")]
-    pub batch_parallelism: usize,
-    #[builder(default = "DEFAULT_TARGET_PARTITIONS")]
-    pub target_partitions: usize,
+    /// The number of parallel tasks to execute. used for scan and join.
+    #[builder(default = "DEFAULT_EXECUTOR_PARALLELISM")]
+    pub executor_parallelism: usize,
+    /// The number of parallel tasks to output. Only used for repartitioning.
+    #[builder(default = "DEFAULT_OUTPUT_PARALLELISM")]
+    pub output_parallelism: usize,
     #[builder(default = "DEFAULT_PREFIX.to_owned()")]
     pub data_file_prefix: String,
     #[builder(default = "DEFAULT_TARGET_FILE_SIZE")]

--- a/core/src/executor/datafusion/datafusion_processor.rs
+++ b/core/src/executor/datafusion/datafusion_processor.rs
@@ -166,7 +166,7 @@ pub struct DatafusionTableRegister {
     file_io: FileIO,
     ctx: Arc<SessionContext>,
 
-    batch_parallelism: usize,
+    executor_parallelism: usize,
     max_record_batch_rows: usize,
 }
 
@@ -174,13 +174,13 @@ impl DatafusionTableRegister {
     pub fn new(
         file_io: FileIO,
         ctx: Arc<SessionContext>,
-        batch_parallelism: usize,
+        executor_parallelism: usize,
         max_record_batch_rows: usize,
     ) -> Self {
         DatafusionTableRegister {
             file_io,
             ctx,
-            batch_parallelism,
+            executor_parallelism,
             max_record_batch_rows,
         }
     }
@@ -226,7 +226,7 @@ impl DatafusionTableRegister {
             self.file_io.clone(),
             need_seq_num,
             need_file_path_and_pos,
-            self.batch_parallelism,
+            self.executor_parallelism,
             self.max_record_batch_rows,
         );
 

--- a/core/src/executor/datafusion/datafusion_processor.rs
+++ b/core/src/executor/datafusion/datafusion_processor.rs
@@ -17,15 +17,14 @@
 use std::sync::Arc;
 
 use crate::{
+    CompactionConfig,
     error::{CompactionError, Result},
     executor::InputFileScanTasks,
-    CompactionConfig,
 };
 use datafusion::{
     execution::SendableRecordBatchStream,
     physical_plan::{
-        execute_stream_partitioned, repartition::RepartitionExec, ExecutionPlan,
-        ExecutionPlanProperties, Partitioning,
+        ExecutionPlan, ExecutionPlanProperties, Partitioning, repartition::RepartitionExec,
     },
     prelude::{SessionConfig, SessionContext},
 };
@@ -54,13 +53,13 @@ pub struct DatafusionProcessor {
 impl DatafusionProcessor {
     pub fn new(config: Arc<CompactionConfig>, file_io: FileIO) -> Self {
         let session_config = SessionConfig::new()
-            .with_target_partitions(config.target_partitions)
+            .with_target_partitions(config.executor_parallelism)
             .with_batch_size(config.max_record_batch_rows);
         let ctx = Arc::new(SessionContext::new_with_config(session_config));
         let table_register = DatafusionTableRegister::new(
             file_io,
             ctx.clone(),
-            config.batch_parallelism,
+            config.executor_parallelism,
             config.max_record_batch_rows,
         );
         Self {
@@ -144,18 +143,21 @@ impl DatafusionProcessor {
         // Conditionally create a new physical_plan if repartitioning is needed
         let plan_to_execute: Arc<dyn ExecutionPlan + 'static> =
             if physical_plan.output_partitioning().partition_count()
-                != self.config.target_partitions
+                != self.config.output_parallelism
             {
                 Arc::new(RepartitionExec::try_new(
                     physical_plan,
-                    Partitioning::RoundRobinBatch(self.config.target_partitions),
+                    Partitioning::RoundRobinBatch(self.config.output_parallelism),
                 )?)
             } else {
                 physical_plan
             };
 
-        let batches = execute_stream_partitioned(plan_to_execute, self.ctx.task_ctx())?;
-
+        // we must execute the plan with output parallelism, target_partitions is not used for repartitioning
+        let mut batches = Vec::with_capacity(self.config.output_parallelism);
+        for i in 0..self.config.output_parallelism {
+            batches.push(plan_to_execute.execute(i, self.ctx.task_ctx())?);
+        }
         Ok((batches, input_schema))
     }
 }

--- a/core/src/executor/datafusion/file_scan_task_table_provider.rs
+++ b/core/src/executor/datafusion/file_scan_task_table_provider.rs
@@ -37,7 +37,7 @@ pub struct IcebergFileScanTaskTableProvider {
     file_io: FileIO,
     need_seq_num: bool,
     need_file_path_and_pos: bool,
-    batch_parallelism: usize,
+    executor_parallelism: usize,
     max_record_batch_rows: usize,
 }
 impl IcebergFileScanTaskTableProvider {
@@ -47,7 +47,7 @@ impl IcebergFileScanTaskTableProvider {
         file_io: FileIO,
         need_seq_num: bool,
         need_file_path_and_pos: bool,
-        batch_parallelism: usize,
+        executor_parallelism: usize,
         max_record_batch_rows: usize,
     ) -> Self {
         Self {
@@ -56,7 +56,7 @@ impl IcebergFileScanTaskTableProvider {
             file_io,
             need_seq_num,
             need_file_path_and_pos,
-            batch_parallelism,
+            executor_parallelism,
             max_record_batch_rows,
         }
     }
@@ -94,7 +94,7 @@ impl TableProvider for IcebergFileScanTaskTableProvider {
             &self.file_io,
             self.need_seq_num,
             self.need_file_path_and_pos,
-            self.batch_parallelism,
+            self.executor_parallelism,
             self.max_record_batch_rows,
         )?))
     }

--- a/core/src/executor/datafusion/iceberg_file_task_scan.rs
+++ b/core/src/executor/datafusion/iceberg_file_task_scan.rs
@@ -120,7 +120,7 @@ impl IcebergFileTaskScan {
         file_io: &FileIO,
         need_seq_num: bool,
         need_file_path_and_pos: bool,
-        batch_parallelism: usize,
+        executor_parallelism: usize,
         max_record_batch_rows: usize,
     ) -> Result<Self, DataFusionError> {
         let output_schema = match projection {
@@ -152,7 +152,7 @@ impl IcebergFileTaskScan {
         } else {
             file_scan_tasks
         };
-        let file_scan_tasks_group = split_n_vecs(file_scan_tasks_projection, batch_parallelism);
+        let file_scan_tasks_group = split_n_vecs(file_scan_tasks_projection, executor_parallelism);
         let plan_properties =
             Self::compute_properties(output_schema.clone(), file_scan_tasks_group.len());
         let predicates = convert_filters_to_predicate(filters);

--- a/core/src/executor/datafusion/iceberg_file_task_scan.rs
+++ b/core/src/executor/datafusion/iceberg_file_task_scan.rs
@@ -730,7 +730,7 @@ mod tests {
         let mut buffer = RecordBatchBuffer::new(max_rows);
 
         buffer.add(create_test_batch(50, None)).unwrap(); // current_rows = 50
-                                                          // This batch makes current_rows exactly max_rows
+        // This batch makes current_rows exactly max_rows
         let exact_fill_batch = create_test_batch(50, None);
         assert!(buffer.add(exact_fill_batch).unwrap().is_none()); // 50 + 50 = 100. No yield yet.
         assert_eq!(buffer.current_rows, 100);


### PR DESCRIPTION
old plan is scan(100) -> repartition(100->4) -> join(4)  -> 4 batches -> 4 writer

now is scan(100) -> join(100) -> repartition(100->4) -> 4 batches -> 4 writer


This pull request updates the configuration and execution logic for parallelism in the compaction process across multiple files. The changes replace `batch_parallelism` and `target_partitions` with `executor_parallelism` and `output_parallelism` to better align with their respective roles in scan, join, and repartitioning tasks. Additionally, the changes propagate these updates across various components, ensuring consistency in the codebase.

### Configuration Updates:

* [`core/src/config/mod.rs`](diffhunk://#diff-26ab583bc154fdb10c63d7cc90045a6026ad6497efe790fe257b60ceb1a15ea7L22-R23): Replaced `DEFAULT_BATCH_PARALLELISM` and `DEFAULT_TARGET_PARTITIONS` with `DEFAULT_EXECUTOR_PARALLELISM` and `DEFAULT_OUTPUT_PARALLELISM`. Updated documentation to clarify their roles in scan/join and repartitioning tasks. [[1]](diffhunk://#diff-26ab583bc154fdb10c63d7cc90045a6026ad6497efe790fe257b60ceb1a15ea7L22-R23) [[2]](diffhunk://#diff-26ab583bc154fdb10c63d7cc90045a6026ad6497efe790fe257b60ceb1a15ea7L32-R45)

### Execution Logic Adjustments:

* [`core/src/executor/datafusion/datafusion_processor.rs`](diffhunk://#diff-ce2ec5fb513cf7adb327b4cc2864593890992fbcc822c089581d19fb7e6a204fL57-R63): Updated `DatafusionProcessor` and `DatafusionTableRegister` to use `executor_parallelism` instead of `batch_parallelism` for session configuration and table registration. Adjusted logic for repartitioning to use `output_parallelism`. [[1]](diffhunk://#diff-ce2ec5fb513cf7adb327b4cc2864593890992fbcc822c089581d19fb7e6a204fL57-R63) [[2]](diffhunk://#diff-ce2ec5fb513cf7adb327b4cc2864593890992fbcc822c089581d19fb7e6a204fL147-L158) [[3]](diffhunk://#diff-ce2ec5fb513cf7adb327b4cc2864593890992fbcc822c089581d19fb7e6a204fL167-R181) [[4]](diffhunk://#diff-ce2ec5fb513cf7adb327b4cc2864593890992fbcc822c089581d19fb7e6a204fL227-R227)

### File Scan Task Updates:

* [`core/src/executor/datafusion/file_scan_task_table_provider.rs`](diffhunk://#diff-8ac82d3a9032fb124ce3f7e04294bf9cf81936acccdcb30edd360a1e305414fcL40-R40): Replaced `batch_parallelism` with `executor_parallelism` in `IcebergFileScanTaskTableProvider` for file scan task handling. [[1]](diffhunk://#diff-8ac82d3a9032fb124ce3f7e04294bf9cf81936acccdcb30edd360a1e305414fcL40-R40) [[2]](diffhunk://#diff-8ac82d3a9032fb124ce3f7e04294bf9cf81936acccdcb30edd360a1e305414fcL50-R50) [[3]](diffhunk://#diff-8ac82d3a9032fb124ce3f7e04294bf9cf81936acccdcb30edd360a1e305414fcL59-R59) [[4]](diffhunk://#diff-8ac82d3a9032fb124ce3f7e04294bf9cf81936acccdcb30edd360a1e305414fcL97-R97)
* [`core/src/executor/datafusion/iceberg_file_task_scan.rs`](diffhunk://#diff-49fda4940475cd762e16845a9cc66ebda5f41751ae015ac46b4dc0df4259139bL123-R123): Updated `IcebergFileTaskScan` to use `executor_parallelism` for splitting file scan tasks into groups. [[1]](diffhunk://#diff-49fda4940475cd762e16845a9cc66ebda5f41751ae015ac46b4dc0df4259139bL123-R123) [[2]](diffhunk://#diff-49fda4940475cd762e16845a9cc66ebda5f41751ae015ac46b4dc0df4259139bL155-R155)

### Compaction Executor Update:

* [`core/src/executor/datafusion/mod.rs`](diffhunk://#diff-3967917dd0985da6644fb89b2b1c534021155a64f317a378e71513dbbe01b5c2L73-R73): Adjusted `DataFusionExecutor` to use `executor_parallelism` for creating futures during execution.
