### PR TITLE
chore: bump mixtrics to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,9 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "mixtrics"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749ed12bab176c8a42c13a679dd2de12876d5ad4abe7525548e31ae001a9ebbf"
+checksum = "adbcddf5a90b959eea97ae505e0391f5c6dd411fbf546d43b9c59ad1c3bd4391"
 dependencies = [
  "itertools 0.14.0",
  "parking_lot",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ iceberg = { workspace = true }
 iceberg-catalog-memory = { workspace = true }
 iceberg-datafusion = { workspace = true }
 itertools = "0.13.0"
-mixtrics = "0.1.0"
+mixtrics = "0.2.0"
 parquet = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
(Better switch to otlp ecosystem, but let's bump mixtrics first.