### PR TITLE
feat(writer): add mutil writer close 

### DIFF
--- a/core/src/executor/iceberg_writer/rolling_iceberg_writer.rs
+++ b/core/src/executor/iceberg_writer/rolling_iceberg_writer.rs
@@ -15,25 +15,30 @@
  */
 
 use datafusion::arrow::array::RecordBatch;
-use iceberg::Result;
+use iceberg::{ErrorKind, Result};
 use iceberg::{
     spec::DataFile,
     writer::{CurrentFileStatus, IcebergWriter, IcebergWriterBuilder},
 };
+use tokio::task::JoinHandle;
+use futures::future;
 
-#[derive(Clone)]
 /// RollingIcebergWriter wraps an IcebergWriter and splits output files by target size.
 pub struct RollingIcebergWriter<B, D> {
     /// Builder for creating new inner writers.
     inner_writer_builder: B,
     /// The current active writer.
-    inner_writer: D,
+    inner_writer: Option<D>,
     /// Target file size in bytes. When exceeded, a new file is started.
     target_file_size: u64,
     /// Collected data files that have been closed.
     data_files: Vec<DataFile>,
     /// Current written size of the active file.
     current_written_size: u64,
+    /// Futures for all closing writers.
+    close_futures: Vec<JoinHandle<Result<Vec<DataFile>>>>,
+    /// Maximum number of concurrent close operations allowed.
+    max_concurrent_closes: usize,
 }
 
 #[async_trait::async_trait]
@@ -53,22 +58,82 @@ where
             input_size as u64,
             self.target_file_size,
         ) {
-            let data_files = self.inner_writer.close().await?;
-            self.data_files.extend(data_files);
-            self.inner_writer = self.inner_writer_builder.clone().build().await?;
+            // Take the current writer and spawn its close operation
+            if let Some(mut inner_writer) = self.inner_writer.take() {
+                // If we've reached the max concurrent closes, wait for one to complete
+                if self.close_futures.len() >= self.max_concurrent_closes {
+                    self.wait_for_one_close().await?;
+                }
+                
+                let close_handle = tokio::spawn(async move {
+                    inner_writer.close().await
+                });
+                self.close_futures.push(close_handle);
+            }
+            
+            // Create a new writer
+            self.inner_writer = Some(self.inner_writer_builder.clone().build().await?);
             self.current_written_size = 0;
         }
+        
         // Write the batch to the current writer.
-        self.inner_writer.write(input).await?;
-        self.current_written_size += input_size as u64;
+        if let Some(writer) = &mut self.inner_writer {
+            writer.write(input).await?;
+            self.current_written_size += input_size as u64;
+        }
         Ok(())
     }
 
     /// Close the writer, ensuring all data files are finalized and returned.
     async fn close(&mut self) -> Result<Vec<DataFile>> {
         let mut data_files = std::mem::take(&mut self.data_files);
-        data_files.extend(self.inner_writer.close().await?);
+        
+        // Wait for all pending close operations to complete
+        let close_futures = std::mem::take(&mut self.close_futures);
+        for close_handle in close_futures {
+            match close_handle.await {
+                Ok(Ok(files)) => data_files.extend(files),
+                Ok(Err(e)) => return Err(e),
+                Err(e) => return Err(iceberg::Error::new(
+                    ErrorKind::Unexpected,
+                    format!("Failed to join close task: {}", e)
+                )),
+            }
+        }
+        
+        // Close the current writer
+        if let Some(mut writer) = self.inner_writer.take() {
+            data_files.extend(writer.close().await?);
+        }
         Ok(data_files)
+    }
+}
+
+impl<B, D> RollingIcebergWriter<B, D> {
+    /// Wait for one close operation to complete and collect its result.
+    async fn wait_for_one_close(&mut self) -> Result<()> {
+        if self.close_futures.is_empty() {
+            return Ok(());
+        }
+
+        // Use select_all to wait for the first future to complete
+        let (result, _index, remaining) = future::select_all(std::mem::take(&mut self.close_futures)).await;
+        
+        // Put back the remaining futures
+        self.close_futures = remaining;
+        
+        // Handle the completed result
+        match result {
+            Ok(Ok(files)) => {
+                self.data_files.extend(files);
+                Ok(())
+            }
+            Ok(Err(e)) => Err(e),
+            Err(e) => Err(iceberg::Error::new(
+                ErrorKind::Unexpected,
+                format!("Failed to join close task: {}", e)
+            ))
+        }
     }
 }
 
@@ -99,6 +164,7 @@ pub fn need_build_new_file(
 pub struct RollingIcebergWriterBuilder<B> {
     inner_builder: B,
     target_file_size: u64,
+    max_concurrent_closes: usize,
 }
 
 impl<B> RollingIcebergWriterBuilder<B> {
@@ -107,7 +173,14 @@ impl<B> RollingIcebergWriterBuilder<B> {
         Self {
             inner_builder,
             target_file_size,
+            max_concurrent_closes: 10, // Default value
         }
+    }
+    
+    /// Set the maximum number of concurrent close operations.
+    pub fn with_max_concurrent_closes(mut self, max_concurrent_closes: usize) -> Self {
+        self.max_concurrent_closes = max_concurrent_closes;
+        self
     }
 }
 
@@ -123,10 +196,12 @@ where
     async fn build(self) -> Result<Self::R> {
         Ok(RollingIcebergWriter {
             inner_writer_builder: self.inner_builder.clone(),
-            inner_writer: self.inner_builder.build().await?,
+            inner_writer: Some(self.inner_builder.build().await?),
             target_file_size: self.target_file_size,
             data_files: Vec::new(),
             current_written_size: 0,
+            close_futures: Vec::new(),
+            max_concurrent_closes: self.max_concurrent_closes,
         })
     }
 }


### PR DESCRIPTION
This pull request refactors the `RollingIcebergWriter` to support concurrent closing of files and introduces a configurable limit for the maximum number of concurrent close operations. The changes enhance performance by enabling asynchronous handling of file closures and improve flexibility with the new configuration option.