### PR TITLE
Feature: Expose config to control column identifier normalization

### DIFF
--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -24,6 +24,7 @@ pub const DEFAULT_TARGET_FILE_SIZE: u64 = 1024 * 1024 * 1024; // 1 GB
 pub const DEFAULT_VALIDATE_COMPACTION: bool = false;
 pub const DEFAULT_MAX_RECORD_BATCH_ROWS: usize = 1024;
 pub const DEFAULT_MAX_CONCURRENT_CLOSES: usize = 4;
+pub const DEFAULT_NORMALIZED_COLUMN_IDENTIFIERS: bool = true;
 
 // Helper function for the default WriterProperties
 fn default_writer_properties() -> WriterProperties {
@@ -60,4 +61,10 @@ pub struct CompactionConfig {
     /// Parquet writer properties for output files
     #[builder(default = "default_writer_properties()")]
     pub write_parquet_properties: WriterProperties,
+    /// The executor engine will normalize un-quoted column identifiers to lowercase (default: true).
+    ///
+    /// Some Iceberg engines allow creating tables with case sensitive column names;
+    /// to compact those tables, set this value to false.
+    #[builder(default = "DEFAULT_NORMALIZED_COLUMN_IDENTIFIERS")]
+    pub enable_normalized_column_identifiers: bool,
 }


### PR DESCRIPTION
## Context

Datafusion (the main execution engine in iceberg-compaction) by default expects lower case table names (postgres style). It will convert any unquoted column name to lowercase by default. See [this Github issue](https://github.com/apache/datafusion/issues/1746) for more context.

## Problem

For R2 Data Catalog, we want to manage table maintenance actions (like Compaction) for our customers. This means we won't have control over their table schemas, and we want to be able to compact tables even with case sensitive column names.

We discovered this issue while testing. We like to use the [NYC Taxi Data](https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page) as an easily accessible open dataset for testing Iceberg, and there are a few columns which are case sensitive. If we try to run the `iceberg-compaction` against a table populated with this data, we get the following error (truncated):

```
ERROR: Encountered problem while listing namespaces:
$DataFusion(SchemaError(FieldNotFound { field: Column { relation: None, name: "vendorid" }, 
valid_fields: [Column { relation: Some(Bare { table: "data_file_table" }), name: "VendorID" }, ...
```

## Solution

Datafusion has a property to disable normalization of column identifiers ([Data Fusion Config](https://datafusion.apache.org/user-guide/configs.html)).

```
datafusion.sql_parser.enable_ident_normalization = false
```

So this change proposes adding configuration on the `CompactionConfig` to allow controlling this value. The default value is set to `true`.

## Testing

I manually tested by running `iceberg-compaction` against an Iceberg table (hosted in R2 Data Catalog) generated from a few years of NYC Taxi data. 

- When `.enable_normalized_column_identifiers(true)`, I see the error immediately on attempting to read data.
- When `.enable_normalized_column_identifiers(false)`, the compaction job works as expected.