### PR TITLE
chore: bump iceberg-rust to 18e7965c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,6 +2582,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2813,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef#fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=18e7965cdb87cc42360a303454b2704dad91f59e#18e7965cdb87cc42360a303454b2704dad91f59e"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2841,6 +2852,7 @@ dependencies = [
  "flate2",
  "fnv",
  "futures",
+ "hashbrown 0.17.0",
  "itertools 0.13.0",
  "moka",
  "murmur3",
@@ -2871,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef#fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=18e7965cdb87cc42360a303454b2704dad91f59e#18e7965cdb87cc42360a303454b2704dad91f59e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2886,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef#fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=18e7965cdb87cc42360a303454b2704dad91f59e#18e7965cdb87cc42360a303454b2704dad91f59e"
 dependencies = [
  "async-trait",
  "base64",
@@ -2972,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef#fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=18e7965cdb87cc42360a303454b2704dad91f59e#18e7965cdb87cc42360a303454b2704dad91f59e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,17 @@ datafusion = "53.0"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "18e7965cdb87cc42360a303454b2704dad91f59e", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "18e7965cdb87cc42360a303454b2704dad91f59e" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "18e7965cdb87cc42360a303454b2704dad91f59e" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "18e7965cdb87cc42360a303454b2704dad91f59e" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fb290e4c9473b1fb4b582e9ac88a8fe08d2265ef" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "18e7965cdb87cc42360a303454b2704dad91f59e" }
 
 parquet = { version = "58.1", features = ["async"] }
 port_scanner = "0.1.5"

--- a/integration-tests/src/test_utils/generator.rs
+++ b/integration-tests/src/test_utils/generator.rs
@@ -97,7 +97,9 @@ impl<B> SharedIcebergWriterBuilder<B> {
 
 #[async_trait::async_trait]
 impl<B, I, O> IcebergWriterBuilder<I, O> for SharedIcebergWriterBuilder<B>
-where B: IcebergWriterBuilder<I, O>
+where
+    B: IcebergWriterBuilder<I, O>,
+    I: Send + 'static,
 {
     type R = B::R;
 


### PR DESCRIPTION
Upstream changes included:
- feat: add write_with_position for IcebergWriter (#149)
- perf: avoid extra copy in DeletionVectorWriter::write (#150)
- fix(transaction): correct previous-snapshot lookup for summary rollup (#151)
- fix(transaction): account for removed files in snapshot summary (#152)

IcebergWriterBuilder now requires `I: Send + 'static`, so add the bound to the SharedIcebergWriterBuilder impl in integration tests.