### PR TITLE
chore: bump iceberg-rust to 11e09f86

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=18e7965cdb87cc42360a303454b2704dad91f59e#18e7965cdb87cc42360a303454b2704dad91f59e"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=11e09f86c908711770eae2f77220f286adccc58b#11e09f86c908711770eae2f77220f286adccc58b"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=18e7965cdb87cc42360a303454b2704dad91f59e#18e7965cdb87cc42360a303454b2704dad91f59e"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=11e09f86c908711770eae2f77220f286adccc58b#11e09f86c908711770eae2f77220f286adccc58b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=18e7965cdb87cc42360a303454b2704dad91f59e#18e7965cdb87cc42360a303454b2704dad91f59e"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=11e09f86c908711770eae2f77220f286adccc58b#11e09f86c908711770eae2f77220f286adccc58b"
 dependencies = [
  "async-trait",
  "base64",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=18e7965cdb87cc42360a303454b2704dad91f59e#18e7965cdb87cc42360a303454b2704dad91f59e"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=11e09f86c908711770eae2f77220f286adccc58b#11e09f86c908711770eae2f77220f286adccc58b"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,17 @@ datafusion = "53.0"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "18e7965cdb87cc42360a303454b2704dad91f59e", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "11e09f86c908711770eae2f77220f286adccc58b", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "18e7965cdb87cc42360a303454b2704dad91f59e" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "18e7965cdb87cc42360a303454b2704dad91f59e" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "18e7965cdb87cc42360a303454b2704dad91f59e" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "11e09f86c908711770eae2f77220f286adccc58b" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "11e09f86c908711770eae2f77220f286adccc58b" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "11e09f86c908711770eae2f77220f286adccc58b" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "18e7965cdb87cc42360a303454b2704dad91f59e" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "11e09f86c908711770eae2f77220f286adccc58b" }
 
 parquet = { version = "58.1", features = ["async"] }
 port_scanner = "0.1.5"


### PR DESCRIPTION
Bumps to the latest version of Iceberg Rust, which adds a fix to the ObjectCache.