### PR TITLE
feat: plumb optional FairSpillPool memory cap into DatafusionProcessor

### DIFF
--- a/core/src/compaction/validator.rs
+++ b/core/src/compaction/validator.rs
@@ -113,7 +113,7 @@ impl CompactionValidator {
             validator_config,
             executor_parallelism,
             table.file_io().clone(),
-        );
+        )?;
 
         Ok(Self {
             datafusion_processor,

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -417,6 +417,25 @@ pub struct CompactionExecutionConfig {
     /// **Note**: This is currently experimental and may not be stable.
     #[builder(default = "DEFAULT_ENABLE_PREFETCH")]
     pub enable_prefetch: bool,
+
+    /// Optional bound on `DataFusion`'s session memory pool, in bytes.
+    ///
+    /// When `Some(bytes)`, the [`SessionContext`](datafusion::prelude::SessionContext)
+    /// is constructed with a [`FairSpillPool`](datafusion::execution::memory_pool::FairSpillPool)
+    /// of `bytes` capacity, so high-cardinality compactions spill to disk
+    /// instead of consuming unbounded heap. This is the recommended setting
+    /// when running compaction inside a memory-constrained container — pair
+    /// it with the operator's cgroup memory limit (typical: 0.75 × limit).
+    ///
+    /// When `None` (default), the upstream behavior is preserved:
+    /// `DataFusion` allocates without a pool ceiling and relies on the OS
+    /// / cgroup to reap the process on memory exhaustion.
+    ///
+    /// Spill files are written under [`std::env::temp_dir`] by
+    /// `DataFusion`'s default `DiskManager`; ensure the runtime has enough
+    /// ephemeral storage for the working set.
+    #[builder(default)]
+    pub memory_pool_bytes: Option<u64>,
 }
 
 impl Default for CompactionExecutionConfig {

--- a/core/src/executor/datafusion/datafusion_processor.rs
+++ b/core/src/executor/datafusion/datafusion_processor.rs
@@ -18,6 +18,8 @@ use std::sync::Arc;
 
 use datafusion::arrow::compute::SortOptions;
 use datafusion::execution::SendableRecordBatchStream;
+use datafusion::execution::memory_pool::FairSpillPool;
+use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::physical_expr::PhysicalSortExpr;
 use datafusion::physical_expr::expressions::Column;
 use datafusion::physical_expr_common::sort_expr::LexOrdering;
@@ -58,7 +60,7 @@ impl DatafusionProcessor {
         execution_config: Arc<CompactionExecutionConfig>,
         executor_parallelism: usize,
         file_io: FileIO,
-    ) -> Self {
+    ) -> Result<Self> {
         let session_config = SessionConfig::new()
             .with_target_partitions(executor_parallelism)
             .with_batch_size(execution_config.max_record_batch_rows)
@@ -66,7 +68,29 @@ impl DatafusionProcessor {
                 "datafusion.sql_parser.enable_ident_normalization",
                 execution_config.enable_normalized_column_identifiers,
             );
-        let ctx = Arc::new(SessionContext::new_with_config(session_config));
+        // When the operator caps DataFusion's session memory pool, install a
+        // `FairSpillPool` with that capacity so spillable operators (sort,
+        // hash aggregation, repartition) bound peak heap use and spill to
+        // `std::env::temp_dir` instead of OOMing the process. Without a pool
+        // configured, DataFusion runs unbounded and relies on the OS / cgroup
+        // reaper, which is exactly the failure mode this knob exists to avoid.
+        let ctx = if let Some(pool_bytes) = execution_config.memory_pool_bytes {
+            let pool = Arc::new(FairSpillPool::new(pool_bytes as usize));
+            let runtime_env = RuntimeEnvBuilder::new()
+                .with_memory_pool(pool)
+                .build_arc()
+                .map_err(|e| {
+                    CompactionError::Config(format!(
+                        "failed to build datafusion runtime env with memory_pool_bytes={pool_bytes}: {e}"
+                    ))
+                })?;
+            Arc::new(SessionContext::new_with_config_rt(
+                session_config,
+                runtime_env,
+            ))
+        } else {
+            Arc::new(SessionContext::new_with_config(session_config))
+        };
         let table_register = DatafusionTableRegister::new(
             file_io,
             ctx.clone(),
@@ -75,10 +99,10 @@ impl DatafusionProcessor {
             execution_config.enable_prefetch,
         );
 
-        Self {
+        Ok(Self {
             table_register,
             ctx,
-        }
+        })
     }
 
     /// Registers all necessary tables (data files, position deletes, equality deletes) with `DataFusion`
@@ -909,6 +933,7 @@ mod tests {
     use iceberg::spec::{NestedField, PrimitiveType, Schema, Type};
 
     use super::*;
+    use crate::config::CompactionExecutionConfigBuilder;
     use crate::executor::datafusion::datafusion_processor::table_name::{
         DATA_FILE_TABLE, POSITION_DELETE_TABLE,
     };
@@ -1869,5 +1894,55 @@ mod tests {
             let result = quote_identifier(input);
             assert_eq!(result, expected);
         }
+    }
+
+    /// `memory_pool_bytes = None` keeps upstream behavior — the
+    /// `SessionContext` is constructed without a configured pool and
+    /// `DatafusionProcessor::new` returns `Ok`.
+    #[test]
+    fn test_datafusion_processor_default_pool_none() {
+        let cfg = Arc::new(CompactionExecutionConfig::default());
+        let file_io = iceberg::io::FileIOBuilder::new("memory")
+            .build()
+            .expect("memory FileIO must build");
+        let processor = DatafusionProcessor::new(cfg, 1, file_io);
+        assert!(processor.is_ok(), "default config should build cleanly");
+    }
+
+    /// `memory_pool_bytes = Some(N)` plumbs through to a `FairSpillPool`
+    /// of capacity `N`. We assert via `runtime_env().memory_pool().pool_size()`,
+    /// which `FairSpillPool` reports as the configured cap.
+    #[test]
+    fn test_datafusion_processor_memory_pool_bytes_plumbs_through() {
+        const POOL_BYTES: u64 = 64 * 1024 * 1024;
+        let cfg = Arc::new(
+            CompactionExecutionConfigBuilder::default()
+                .memory_pool_bytes(Some(POOL_BYTES))
+                .build()
+                .expect("config builds"),
+        );
+        let file_io = iceberg::io::FileIOBuilder::new("memory")
+            .build()
+            .expect("memory FileIO must build");
+        let processor = DatafusionProcessor::new(cfg, 1, file_io)
+            .expect("memory_pool_bytes path must construct cleanly");
+        let pool = processor.ctx.runtime_env().memory_pool.clone();
+        // `MemoryPool::reserved()` is 0 on a fresh pool but `pool_size()` is
+        // not on the trait. Reserve the full cap and verify the limit holds:
+        // a bytes+1 reservation past the cap must error.
+        let consumer =
+            datafusion::execution::memory_pool::MemoryConsumer::new("test").register(&pool);
+        let _ = consumer; // hold the consumer so reservations are tracked
+        let mut reservation =
+            datafusion::execution::memory_pool::MemoryConsumer::new("test_res").register(&pool);
+        // try_grow takes &mut self; keeping the binding mutable.
+        let _ = &mut reservation;
+        reservation
+            .try_grow(POOL_BYTES as usize)
+            .expect("grow up to cap succeeds");
+        assert!(
+            reservation.try_grow(1).is_err(),
+            "growing past pool cap must error — confirms FairSpillPool with the configured size"
+        );
     }
 }

--- a/core/src/executor/datafusion/mod.rs
+++ b/core/src/executor/datafusion/mod.rs
@@ -78,7 +78,7 @@ impl CompactionExecutor for DataFusionExecutor {
             execution_config.clone(),
             executor_parallelism,
             file_io.clone(),
-        )
+        )?
         .execute(datafusion_task_ctx, output_parallelism)
         .await?;
         let arc_input_schema = Arc::new(input_schema);


### PR DESCRIPTION
## Motivation

When running `iceberg-compaction-core` inside a memory-constrained container (e.g. a Kubernetes Pod with a cgroup memory limit), the `SessionContext` is currently constructed without a configured `MemoryPool`, so DataFusion allocates without a ceiling and relies on the OS / cgroup reaper to terminate the process on overshoot. Operators with no insight into upstream defaults end up with two failure modes:

1. Silent OOMKill on a busy run — looks identical to a hang or a crash from the supervisor's view, no helpful diagnostic.
2. Memory pressure with no configurable safety net — operators can tune `max_input_parallelism`, `max_record_batch_rows`, etc., but if a future workload shape (wider strings, new query plan with a sort/aggregate, …) introduces unexpected pressure, there is no hard ceiling.

In production, we hit (1) on a cohort table with a wide `_raw` column. Tightening parallelism worked around the immediate symptom but left a fragile knob: any future cohort growth or new high-cardinality column re-introduces the same failure mode. We want a hard ceiling tied to the cgroup memory limit so the worst case is *spilling* (cron absorbs slowness) rather than *crashloop* (cron does not).

## Change

Add `CompactionExecutionConfig::memory_pool_bytes: Option<u64>`. Default `None` preserves upstream behaviour.

When `Some(bytes)`, `DatafusionProcessor::new` builds the `SessionContext` with a `FairSpillPool(bytes)` via `RuntimeEnvBuilder`:

```rust
let pool = Arc::new(FairSpillPool::new(pool_bytes as usize));
let runtime_env = RuntimeEnvBuilder::new()
    .with_memory_pool(pool)
    .build_arc()?;
SessionContext::new_with_config_rt(session_config, runtime_env)
```

`FairSpillPool` (vs. `GreedyMemoryPool`) is deliberate — we want spillable operators to spill to `std::env::temp_dir`, not just hard-error.

`DatafusionProcessor::new` becomes `Result`-returning so runtime-env construction errors surface to the caller. The two existing call sites (`executor::datafusion::mod` and `compaction::validator`) propagate via `?`.

## Tests

Two new unit tests in `executor::datafusion::datafusion_processor::tests`:

- `test_datafusion_processor_default_pool_none` — `None` constructs cleanly (back-compat pin).
- `test_datafusion_processor_memory_pool_bytes_plumbs_through` — under `Some(N)`, registering a `MemoryReservation` and growing it past `N` returns `Err`. Proves the pool is installed at the configured size.

121/121 unit tests pass; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean. Rebased on current `main`.

## Empirical validation

We have been running this branch (via a private `[patch]` redirect from a downstream binary) on a real EKS cluster against synthetic cohorts that mirror our production schema:

- Pool installs correctly at the configured size (`Created new FairSpillPool(pool_size=N)` appears in DataFusion debug logs every run).
- Pool errors loudly past cap (`FairSpillPool::try_grow` returns `Err`, surfacing as `CompactionError::Execution`, exit 1, not the cgroup's exit 137 / OOMKilled).
- For typical compaction plans (`SELECT * FROM data_table` with `RepartitionExec`), the pool is rarely the binding constraint — the streaming pipeline keeps spillable-operator reservations small. The pool is most useful as a guard against future `exec_sql` changes that introduce heavy `SortExec` / `AggregateExec`.

## Out of scope

- No change to spill-directory configuration. DataFusion's default `DiskManager` writes spills under `std::env::temp_dir`; an operator-reachable knob for spill directory could land in a follow-up.
- No telemetry / metrics for pool reservations or spills. Could be added by exposing the `RuntimeEnv` through `DatafusionProcessor`.

Diff is ~100 lines including tests; well within the 300-500 line guidance in `CONTRIBUTING.md`.