### PR TITLE
chore: bump iceberg-rust to d6bd578d

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=11e09f86c908711770eae2f77220f286adccc58b#11e09f86c908711770eae2f77220f286adccc58b"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d6bd578d64c396040e707ce2d85c83e64b47d7d6#d6bd578d64c396040e707ce2d85c83e64b47d7d6"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=11e09f86c908711770eae2f77220f286adccc58b#11e09f86c908711770eae2f77220f286adccc58b"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d6bd578d64c396040e707ce2d85c83e64b47d7d6#d6bd578d64c396040e707ce2d85c83e64b47d7d6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=11e09f86c908711770eae2f77220f286adccc58b#11e09f86c908711770eae2f77220f286adccc58b"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d6bd578d64c396040e707ce2d85c83e64b47d7d6#d6bd578d64c396040e707ce2d85c83e64b47d7d6"
 dependencies = [
  "async-trait",
  "base64",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=11e09f86c908711770eae2f77220f286adccc58b#11e09f86c908711770eae2f77220f286adccc58b"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d6bd578d64c396040e707ce2d85c83e64b47d7d6#d6bd578d64c396040e707ce2d85c83e64b47d7d6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,17 @@ datafusion = "53.0"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "11e09f86c908711770eae2f77220f286adccc58b", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d6bd578d64c396040e707ce2d85c83e64b47d7d6", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "11e09f86c908711770eae2f77220f286adccc58b" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "11e09f86c908711770eae2f77220f286adccc58b" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "11e09f86c908711770eae2f77220f286adccc58b" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d6bd578d64c396040e707ce2d85c83e64b47d7d6" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d6bd578d64c396040e707ce2d85c83e64b47d7d6" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d6bd578d64c396040e707ce2d85c83e64b47d7d6" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "11e09f86c908711770eae2f77220f286adccc58b" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d6bd578d64c396040e707ce2d85c83e64b47d7d6" }
 
 parquet = { version = "58.1", features = ["async"] }
 port_scanner = "0.1.5"


### PR DESCRIPTION
Upstream Update:
- `fix: handle all Iceberg types when filling missing columns files after schema evolution`
- `feat: add DataFile::set_partition`