### PR TITLE
chore: bump iceberg-rust for release 2.8 schema drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,7 +2883,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2916,7 +2916,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.7.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=10410fa883791d3b38d3751d050c79223ad4317f#10410fa883791d3b38d3751d050c79223ad4317f"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2bd756526f45f3ffda95745c7c5ab2d3fe0714b0#2bd756526f45f3ffda95745c7c5ab2d3fe0714b0"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2975,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.7.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=10410fa883791d3b38d3751d050c79223ad4317f#10410fa883791d3b38d3751d050c79223ad4317f"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2bd756526f45f3ffda95745c7c5ab2d3fe0714b0#2bd756526f45f3ffda95745c7c5ab2d3fe0714b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2990,7 +2990,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.7.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=10410fa883791d3b38d3751d050c79223ad4317f#10410fa883791d3b38d3751d050c79223ad4317f"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2bd756526f45f3ffda95745c7c5ab2d3fe0714b0#2bd756526f45f3ffda95745c7c5ab2d3fe0714b0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3077,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.7.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=10410fa883791d3b38d3751d050c79223ad4317f#10410fa883791d3b38d3751d050c79223ad4317f"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2bd756526f45f3ffda95745c7c5ab2d3fe0714b0#2bd756526f45f3ffda95745c7c5ab2d3fe0714b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6221,7 +6221,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,17 @@ datafusion = "50"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "10410fa883791d3b38d3751d050c79223ad4317f", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2bd756526f45f3ffda95745c7c5ab2d3fe0714b0", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "10410fa883791d3b38d3751d050c79223ad4317f" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "10410fa883791d3b38d3751d050c79223ad4317f" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "10410fa883791d3b38d3751d050c79223ad4317f" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2bd756526f45f3ffda95745c7c5ab2d3fe0714b0" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2bd756526f45f3ffda95745c7c5ab2d3fe0714b0" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2bd756526f45f3ffda95745c7c5ab2d3fe0714b0" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "10410fa883791d3b38d3751d050c79223ad4317f" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2bd756526f45f3ffda95745c7c5ab2d3fe0714b0" }
 
 parquet = { version = "56.2", features = ["async"] }
 port_scanner = "0.1.5"


### PR DESCRIPTION
## Summary
- bump iceberg-rust to risingwavelabs/iceberg-rust#158
- keep iceberg-compaction compatible with the RisingWave release-2.8 dependency stack

## Testing
- cargo check -p iceberg-compaction-core