### PR TITLE
fix: propagate manifest load errors instead of panicking

### DIFF
--- a/core/src/compaction/mod.rs
+++ b/core/src/compaction/mod.rs
@@ -736,15 +736,12 @@ async fn get_all_files_from_snapshot(
     file_io: &FileIO,
     table_metadata: &iceberg::spec::TableMetadata,
 ) -> Result<(Vec<DataFile>, Vec<DataFile>)> {
-    let manifest_list = snapshot
-        .load_manifest_list(file_io, table_metadata)
-        .await
-        .unwrap();
+    let manifest_list = snapshot.load_manifest_list(file_io, table_metadata).await?;
 
     let mut data_file = vec![];
     let mut delete_file = vec![];
     for manifest_file in manifest_list.entries() {
-        let a = manifest_file.load_manifest(file_io).await.unwrap();
+        let a = manifest_file.load_manifest(file_io).await?;
         let (entry, _) = a.into_parts();
         for i in entry {
             match i.content_type() {


### PR DESCRIPTION
`get_all_files_from_snapshot` called `.unwrap()` on both `Snapshot::load_manifest_list` and `ManifestFile::load_manifest`. The function already returns `Result<_, CompactionError>` and `CompactionError` has `#[from] iceberg::Error`, so these can simply propagate with `?`.

A transient object store error (e.g. an S3 500) during manifest read on the commit-time snapshot reload would otherwise panic the worker thread instead of surfacing as a recoverable `CompactionError::Iceberg` that callers can retry on the next invocation.