### PR TITLE
chore: bump iceberg-rust to 8f7c952f

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d6bd578d64c396040e707ce2d85c83e64b47d7d6#d6bd578d64c396040e707ce2d85c83e64b47d7d6"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=8f7c952f66de9b2d65c1d168eccf32a3fe291a55#8f7c952f66de9b2d65c1d168eccf32a3fe291a55"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d6bd578d64c396040e707ce2d85c83e64b47d7d6#d6bd578d64c396040e707ce2d85c83e64b47d7d6"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=8f7c952f66de9b2d65c1d168eccf32a3fe291a55#8f7c952f66de9b2d65c1d168eccf32a3fe291a55"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d6bd578d64c396040e707ce2d85c83e64b47d7d6#d6bd578d64c396040e707ce2d85c83e64b47d7d6"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=8f7c952f66de9b2d65c1d168eccf32a3fe291a55#8f7c952f66de9b2d65c1d168eccf32a3fe291a55"
 dependencies = [
  "async-trait",
  "base64",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d6bd578d64c396040e707ce2d85c83e64b47d7d6#d6bd578d64c396040e707ce2d85c83e64b47d7d6"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=8f7c952f66de9b2d65c1d168eccf32a3fe291a55#8f7c952f66de9b2d65c1d168eccf32a3fe291a55"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,6 @@
 [workspace]
 resolver = "2"
-members = [
-    "core",
-    "examples/memory-catalog",
-    "examples/rest-catalog",
-    "integration-tests",
-]
+members = ["core", "examples/memory-catalog", "examples/rest-catalog", "integration-tests"]
 
 [workspace.dependencies]
 # Async runtime and utilities
@@ -18,17 +13,12 @@ datafusion = "53.0"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d6bd578d64c396040e707ce2d85c83e64b47d7d6", features = [
-    "storage-s3",
-    "storage-gcs",
-    "storage-azblob",
-    "storage-azdls",
-] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d6bd578d64c396040e707ce2d85c83e64b47d7d6" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d6bd578d64c396040e707ce2d85c83e64b47d7d6" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d6bd578d64c396040e707ce2d85c83e64b47d7d6" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "8f7c952f66de9b2d65c1d168eccf32a3fe291a55", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "8f7c952f66de9b2d65c1d168eccf32a3fe291a55" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "8f7c952f66de9b2d65c1d168eccf32a3fe291a55" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "8f7c952f66de9b2d65c1d168eccf32a3fe291a55" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d6bd578d64c396040e707ce2d85c83e64b47d7d6" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "8f7c952f66de9b2d65c1d168eccf32a3fe291a55" }
 
 parquet = { version = "58.1", features = ["async"] }
 port_scanner = "0.1.5"


### PR DESCRIPTION
Upstream Update:
- `fix: skip opendal TimeoutLayer under madsim`
- `feat: support dropping schema fields`
- `fix(rest): refresh token after unauthorized response`