### PR TITLE
feat: support table scoped file groups

### DIFF
--- a/core/src/compaction/mod.rs
+++ b/core/src/compaction/mod.rs
@@ -1401,6 +1401,8 @@ mod tests {
     };
     use crate::executor::{ExecutorType, RewriteFilesStat};
 
+    mod file_group_scope;
+
     // ----------------------
     // Test helpers to reduce duplication
     // ----------------------

--- a/core/src/compaction/tests/file_group_scope.rs
+++ b/core/src/compaction/tests/file_group_scope.rs
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2025 iceberg-compaction
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use iceberg::memory::{MEMORY_CATALOG_WAREHOUSE, MemoryCatalogBuilder};
+use iceberg::spec::{
+    DataContentType, DataFile, DataFileBuilder, DataFileFormat, Literal, MAIN_BRANCH,
+    PrimitiveLiteral, Struct, Transform, UnboundPartitionSpec,
+};
+use iceberg::table::Table;
+use iceberg::{Catalog, CatalogBuilder, NamespaceIdent, TableCreation, TableIdent};
+use tempfile::TempDir;
+
+use super::{TestEnv, append_and_commit, create_namespace, simple_table_schema};
+use crate::compaction::CompactionPlanner;
+use crate::config::{
+    CompactionPlanningConfig, FileGroupScope, FullCompactionConfigBuilder, GroupingStrategy,
+};
+
+#[tokio::test]
+async fn test_plan_compaction_with_table_file_group_scope() {
+    let env = create_partitioned_test_env().await;
+    let updated_table = append_and_commit(
+        &env.table,
+        env.catalog.as_ref(),
+        partitioned_data_files(&env.table),
+    )
+    .await;
+
+    let partition_scoped_plans = planner(FileGroupScope::Partition)
+        .plan_compaction(&updated_table)
+        .await
+        .unwrap();
+    let table_scoped_plans = planner(FileGroupScope::Table)
+        .plan_compaction(&updated_table)
+        .await
+        .unwrap();
+
+    assert_eq!(partition_scoped_plans.len(), 3);
+    assert_eq!(table_scoped_plans.len(), 1);
+    assert_eq!(table_scoped_plans[0].file_count(), 5);
+    assert_eq!(table_scoped_plans[0].to_branch, MAIN_BRANCH);
+}
+
+fn planner(file_group_scope: FileGroupScope) -> CompactionPlanner {
+    CompactionPlanner::new(CompactionPlanningConfig::Full(
+        FullCompactionConfigBuilder::default()
+            .grouping_strategy(GroupingStrategy::Single)
+            .file_group_scope(file_group_scope)
+            .build()
+            .unwrap(),
+    ))
+}
+
+async fn create_partitioned_test_env() -> TestEnv {
+    let temp_dir = TempDir::new().unwrap();
+    let warehouse_location = temp_dir.path().to_str().unwrap().to_owned();
+    let catalog = Arc::new(
+        MemoryCatalogBuilder::default()
+            .load(
+                "memory",
+                HashMap::from([(
+                    MEMORY_CATALOG_WAREHOUSE.to_owned(),
+                    warehouse_location.clone(),
+                )]),
+            )
+            .await
+            .unwrap(),
+    );
+
+    let namespace_ident = NamespaceIdent::new("test_partitioned_namespace".into());
+    create_namespace(catalog.as_ref(), &namespace_ident).await;
+
+    let table_ident = TableIdent::new(namespace_ident, "test_partitioned_table".into());
+    create_partitioned_table(catalog.as_ref(), &table_ident).await;
+
+    let table = catalog.load_table(&table_ident).await.unwrap();
+
+    TestEnv {
+        temp_dir,
+        warehouse_location,
+        catalog,
+        table_ident,
+        table,
+    }
+}
+
+async fn create_partitioned_table<C: Catalog>(catalog: &C, table_ident: &TableIdent) {
+    let partition_spec = UnboundPartitionSpec::builder()
+        .add_partition_field(1, "id", Transform::Identity)
+        .unwrap()
+        .build();
+
+    let _ = catalog
+        .create_table(
+            &table_ident.namespace,
+            TableCreation::builder()
+                .name(table_ident.name().into())
+                .schema(simple_table_schema())
+                .partition_spec(partition_spec)
+                .build(),
+        )
+        .await
+        .unwrap();
+}
+
+fn partitioned_data_files(table: &Table) -> Vec<DataFile> {
+    let spec_id = table.metadata().default_partition_spec_id();
+    let data_file = |path, partition_id| data_file_with_partition(path, partition_id, spec_id);
+
+    vec![
+        data_file("file:///test/p0_file1.parquet", 0),
+        data_file("file:///test/p0_file2.parquet", 0),
+        data_file("file:///test/p1_file1.parquet", 1),
+        data_file("file:///test/p2_file1.parquet", 2),
+        data_file("file:///test/p2_file2.parquet", 2),
+    ]
+}
+
+fn data_file_with_partition(path: &str, partition_id: i32, partition_spec_id: i32) -> DataFile {
+    DataFileBuilder::default()
+        .content(DataContentType::Data)
+        .file_format(DataFileFormat::Parquet)
+        .file_path(path.to_owned())
+        .file_size_in_bytes(1024)
+        .record_count(10)
+        .partition(partition_value(partition_id))
+        .partition_spec_id(partition_spec_id)
+        .build()
+        .unwrap()
+}
+
+fn partition_value(id: i32) -> Struct {
+    Struct::from_iter(vec![Some(Literal::Primitive(PrimitiveLiteral::Int(id)))])
+}

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -94,6 +94,19 @@ pub enum GroupingStrategy {
     BinPack(BinPackConfig),
 }
 
+/// File-group boundary used before applying the grouping strategy.
+///
+/// `Partition` keeps file groups within one Iceberg partition. `Table` allows
+/// the grouping strategy to see all selected files together.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum FileGroupScope {
+    /// Group files independently within each Iceberg partition.
+    #[default]
+    Partition,
+    /// Group all selected files at table scope.
+    Table,
+}
+
 /// Group-level filters applied after grouping.
 ///
 /// These filters remove groups that don't meet certain criteria. They are
@@ -143,6 +156,13 @@ pub struct SmallFilesConfig {
     #[builder(default)]
     pub grouping_strategy: GroupingStrategy,
 
+    /// Boundary for file groups before applying `grouping_strategy`.
+    ///
+    /// With [`FileGroupScope::Table`], `group_filters` evaluate groups across
+    /// all selected partitions instead of independently per partition.
+    #[builder(default)]
+    pub file_group_scope: FileGroupScope,
+
     /// Optional filters to apply after grouping.
     ///
     /// Groups that don't meet these criteria will be excluded from compaction.
@@ -161,7 +181,7 @@ impl Default for SmallFilesConfig {
 
 /// Configuration for full compaction strategy.
 ///
-/// This strategy performs full compaction of all files in a partition.
+/// This strategy performs full compaction of all selected data files.
 /// Group filters are NOT supported because "full" compaction means processing
 /// ALL files without filtering.
 #[derive(Debug, Clone, Builder)]
@@ -195,6 +215,13 @@ pub struct FullCompactionConfig {
     /// All groups will be compacted regardless of size or file count.
     #[builder(default)]
     pub grouping_strategy: GroupingStrategy,
+
+    /// Boundary for file groups before applying `grouping_strategy`.
+    ///
+    /// Use [`FileGroupScope::Table`] with [`GroupingStrategy::Single`] when a
+    /// full-table compaction must be planned as one file group.
+    #[builder(default)]
+    pub file_group_scope: FileGroupScope,
 }
 
 impl Default for FullCompactionConfig {
@@ -237,6 +264,13 @@ pub struct FilesWithDeletesConfig {
     /// How to group files before compaction.
     #[builder(default)]
     pub grouping_strategy: GroupingStrategy,
+
+    /// Boundary for file groups before applying `grouping_strategy`.
+    ///
+    /// With [`FileGroupScope::Table`], `group_filters` evaluate groups across
+    /// all selected partitions instead of independently per partition.
+    #[builder(default)]
+    pub file_group_scope: FileGroupScope,
 
     /// Minimum number of delete files required to trigger compaction.
     #[builder(default = "DEFAULT_MIN_DELETE_FILE_COUNT_THRESHOLD")]
@@ -328,6 +362,15 @@ impl CompactionPlanningConfig {
             Self::SmallFiles(c) => c.enable_heuristic_output_parallelism,
             Self::Full(c) => c.enable_heuristic_output_parallelism,
             Self::FilesWithDeletes(c) => c.enable_heuristic_output_parallelism,
+        }
+    }
+
+    /// Returns the file-group boundary for the strategy.
+    pub fn file_group_scope(&self) -> FileGroupScope {
+        match self {
+            Self::SmallFiles(c) => c.file_group_scope,
+            Self::Full(c) => c.file_group_scope,
+            Self::FilesWithDeletes(c) => c.file_group_scope,
         }
     }
 }
@@ -548,6 +591,7 @@ impl AutoCompactionConfig {
                     max_output_parallelism: self.max_output_parallelism,
                     enable_heuristic_output_parallelism: self.enable_heuristic_output_parallelism,
                     grouping_strategy: self.grouping_strategy.clone(),
+                    file_group_scope: FileGroupScope::Partition,
                     min_delete_file_count_threshold: self.min_delete_file_count_threshold,
                     group_filters: self.group_filters.clone(),
                 },
@@ -579,6 +623,7 @@ impl AutoCompactionConfig {
                 enable_heuristic_output_parallelism: self.enable_heuristic_output_parallelism,
                 small_file_threshold_bytes: self.small_file_threshold_bytes,
                 grouping_strategy: self.grouping_strategy.clone(),
+                file_group_scope: FileGroupScope::Partition,
                 group_filters: self.group_filters.clone(),
             }))
         } else {
@@ -669,6 +714,50 @@ mod tests {
     fn test_auto_default_budget_is_unbounded() {
         let config = AutoCompactionConfig::default();
         assert_eq!(config.max_auto_plans_per_run, NonZeroUsize::MAX);
+    }
+
+    #[test]
+    fn test_planning_configs_default_to_partition_file_group_scope() {
+        let small_files = SmallFilesConfig::default();
+        assert_eq!(small_files.file_group_scope, FileGroupScope::Partition);
+
+        let full = FullCompactionConfig::default();
+        assert_eq!(full.file_group_scope, FileGroupScope::Partition);
+
+        let files_with_deletes = FilesWithDeletesConfig::default();
+        assert_eq!(
+            files_with_deletes.file_group_scope,
+            FileGroupScope::Partition
+        );
+    }
+
+    #[test]
+    fn test_auto_candidates_use_partition_file_group_scope() {
+        let config = AutoCompactionConfigBuilder::default()
+            .thresholds(AutoThresholds {
+                min_delete_heavy_files_count: 1,
+                min_small_files_count: 1,
+            })
+            .build()
+            .unwrap();
+        let stats = create_test_stats(10, 1, 1);
+
+        let CompactionPlanningConfig::FilesWithDeletes(files_with_deletes) =
+            config.files_with_deletes_candidate(&stats).unwrap()
+        else {
+            panic!("Expected FilesWithDeletes");
+        };
+        let CompactionPlanningConfig::SmallFiles(small_files) =
+            config.small_files_candidate(&stats).unwrap()
+        else {
+            panic!("Expected SmallFiles");
+        };
+
+        assert_eq!(
+            files_with_deletes.file_group_scope,
+            FileGroupScope::Partition
+        );
+        assert_eq!(small_files.file_group_scope, FileGroupScope::Partition);
     }
 
     #[test]

--- a/core/src/file_selection/mod.rs
+++ b/core/src/file_selection/mod.rs
@@ -30,7 +30,7 @@ pub struct SnapshotStats {
     pub delete_heavy_files_count: usize,
 }
 pub use packer::ListPacker;
-pub use strategy::{FileGroup, PlanStrategy};
+pub use strategy::{FileGroup, PlanStrategy, PlanStrategyOptions};
 
 /// File selection service responsible for selecting files for various operations
 pub struct FileSelector;

--- a/core/src/file_selection/strategy.rs
+++ b/core/src/file_selection/strategy.rs
@@ -18,7 +18,8 @@
 //!
 //! Implements a three-stage pipeline:
 //! 1. File filters: Exclude files by size, delete count, or minimum file threshold
-//! 2. Grouping: Combine files using Single (all-in-one) or `BinPack` (First-Fit Decreasing)
+//! 2. Grouping: Choose a file-group scope, then combine files using Single
+//!    (all-in-one) or `BinPack` (First-Fit Decreasing)
 //! 3. Group filters: Remove groups below size/count thresholds
 //!
 //! Parallelism is calculated per group based on file size and count constraints.
@@ -28,7 +29,7 @@ use std::collections::HashMap;
 use iceberg::scan::FileScanTask;
 
 use super::packer::ListPacker;
-use crate::config::{CompactionPlanningConfig, GroupingStrategy, SPLIT_OVERHEAD};
+use crate::config::{CompactionPlanningConfig, FileGroupScope, GroupingStrategy, SPLIT_OVERHEAD};
 use crate::{CompactionError, Result};
 
 /// Bundle of data files and associated delete files for compaction.
@@ -388,16 +389,26 @@ pub enum GroupingStrategyEnum {
 }
 
 impl GroupingStrategyEnum {
+    /// Groups files independently within each Iceberg partition.
+    ///
+    /// This preserves the historical public API behavior. Use [`PlanStrategy`]
+    /// with [`FileGroupScope::Table`] when the grouping strategy should see
+    /// all selected files together.
     pub fn group_files<I>(&self, data_files: I) -> Vec<FileGroup>
-    where I: Iterator<Item = FileScanTask> {
-        // Note that if the table is unpartitioned, the hash map will have a single entry.
-        group_files_by_partition(data_files)
-            .into_iter()
-            .flat_map(|(_partition_key, files)| match self {
-                GroupingStrategyEnum::Single(strategy) => strategy.group_files(files.into_iter()),
-                GroupingStrategyEnum::BinPack(strategy) => strategy.group_files(files.into_iter()),
-            })
+    where I: IntoIterator<Item = FileScanTask> {
+        group_files_by_partition(data_files.into_iter())
+            .into_values()
+            .flat_map(|files| self.group_files_without_partitioning(files))
             .collect()
+    }
+
+    fn group_files_without_partitioning<I>(&self, data_files: I) -> Vec<FileGroup>
+    where I: IntoIterator<Item = FileScanTask> {
+        let data_files = data_files.into_iter();
+        match self {
+            GroupingStrategyEnum::Single(strategy) => strategy.group_files(data_files),
+            GroupingStrategyEnum::BinPack(strategy) => strategy.group_files(data_files),
+        }
     }
 }
 
@@ -621,17 +632,25 @@ impl std::fmt::Display for MinGroupFileCountStrategy {
     }
 }
 
-/// Three-stage pipeline: file filters → grouping → group filters → parallelism calculation.
+/// Options for constructing a [`PlanStrategy`].
 ///
-/// Filters and group filters are applied sequentially. See [`execute`](Self::execute) for details.
+/// The default file group scope is [`FileGroupScope::Partition`], matching the
+/// historical behavior of [`PlanStrategy::new`].
 #[derive(Debug)]
-pub struct PlanStrategy {
+pub struct PlanStrategyOptions {
     file_filters: Vec<Box<dyn FileFilterStrategy>>,
     grouping: GroupingStrategyEnum,
+    file_group_scope: FileGroupScope,
     group_filters: Vec<Box<dyn GroupFilterStrategy>>,
 }
 
-impl PlanStrategy {
+impl PlanStrategyOptions {
+    /// Creates options from the explicit file-selection pipeline stages.
+    ///
+    /// The file group scope defaults to [`FileGroupScope::Partition`]. Use
+    /// [`with_file_group_scope`](Self::with_file_group_scope) to opt into
+    /// table-scoped grouping.
+    #[must_use]
     pub fn new(
         file_filters: Vec<Box<dyn FileFilterStrategy>>,
         grouping: GroupingStrategyEnum,
@@ -640,16 +659,65 @@ impl PlanStrategy {
         Self {
             file_filters,
             grouping,
+            file_group_scope: FileGroupScope::Partition,
             group_filters,
         }
     }
 
+    /// Sets the scope used before the grouping strategy runs.
+    #[must_use]
+    pub fn with_file_group_scope(mut self, file_group_scope: FileGroupScope) -> Self {
+        self.file_group_scope = file_group_scope;
+        self
+    }
+}
+
+/// Three-stage pipeline: file filters → grouping → group filters → parallelism calculation.
+///
+/// Filters and group filters are applied sequentially. See [`execute`](Self::execute) for details.
+#[derive(Debug)]
+pub struct PlanStrategy {
+    file_filters: Vec<Box<dyn FileFilterStrategy>>,
+    grouping: GroupingStrategyEnum,
+    file_group_scope: FileGroupScope,
+    group_filters: Vec<Box<dyn GroupFilterStrategy>>,
+}
+
+impl PlanStrategy {
+    /// Creates a plan strategy with partition-scoped grouping.
+    ///
+    /// This preserves the historical public constructor behavior. Use
+    /// [`new_with_options`](Self::new_with_options) when non-default strategy
+    /// options are needed.
+    #[must_use]
+    pub fn new(
+        file_filters: Vec<Box<dyn FileFilterStrategy>>,
+        grouping: GroupingStrategyEnum,
+        group_filters: Vec<Box<dyn GroupFilterStrategy>>,
+    ) -> Self {
+        Self::new_with_options(PlanStrategyOptions::new(
+            file_filters,
+            grouping,
+            group_filters,
+        ))
+    }
+
+    /// Creates a plan strategy from explicit construction options.
+    #[must_use]
+    pub fn new_with_options(options: PlanStrategyOptions) -> Self {
+        Self {
+            file_filters: options.file_filters,
+            grouping: options.grouping,
+            file_group_scope: options.file_group_scope,
+            group_filters: options.group_filters,
+        }
+    }
+
     /// Executes the pipeline:
-    /// 1. Pre-group files by partition (if the a partition spec is present)
-    /// 2. Apply each file filter sequentially
-    /// 3. Group files using grouping strategy
-    /// 4. Apply each group filter sequentially
-    /// 5. Calculate parallelism for each group via [`FileGroup::with_calculated_parallelism`]
+    /// 1. Apply each file filter sequentially
+    /// 2. Group files using the configured file-group scope and grouping strategy
+    /// 3. Apply each group filter sequentially
+    /// 4. Calculate parallelism for each group via [`FileGroup::with_calculated_parallelism`]
     ///
     /// # Errors
     /// Propagates errors from parallelism calculation (fails if group has 0 bytes).
@@ -663,7 +731,7 @@ impl PlanStrategy {
             filtered_files = filter.filter(filtered_files);
         }
 
-        let file_groups = self.grouping.group_files(filtered_files.into_iter());
+        let file_groups = self.group_files(filtered_files);
 
         let mut file_groups = file_groups;
         for filter in &self.group_filters {
@@ -674,6 +742,13 @@ impl PlanStrategy {
             .into_iter()
             .map(|group| group.with_calculated_parallelism(config))
             .collect()
+    }
+
+    fn group_files(&self, data_files: Vec<FileScanTask>) -> Vec<FileGroup> {
+        match self.file_group_scope {
+            FileGroupScope::Table => self.grouping.group_files_without_partitioning(data_files),
+            FileGroupScope::Partition => self.grouping.group_files(data_files),
+        }
     }
 
     /// Constructs grouping enum and group filters from config.
@@ -733,7 +808,10 @@ impl PlanStrategy {
             config.group_filters.as_ref(),
         );
 
-        Self::new(file_filters, grouping, group_filters)
+        Self::new_with_options(
+            PlanStrategyOptions::new(file_filters, grouping, group_filters)
+                .with_file_group_scope(config.file_group_scope),
+        )
     }
 
     /// Constructs strategy for full compaction.
@@ -746,7 +824,10 @@ impl PlanStrategy {
         let (grouping, group_filters) =
             Self::build_grouping_and_filters(&config.grouping_strategy, None);
 
-        Self::new(file_filters, grouping, group_filters)
+        Self::new_with_options(
+            PlanStrategyOptions::new(file_filters, grouping, group_filters)
+                .with_file_group_scope(config.file_group_scope),
+        )
     }
 
     /// Constructs strategy for files with delete files.
@@ -766,7 +847,10 @@ impl PlanStrategy {
             config.group_filters.as_ref(),
         );
 
-        Self::new(file_filters, grouping, group_filters)
+        Self::new_with_options(
+            PlanStrategyOptions::new(file_filters, grouping, group_filters)
+                .with_file_group_scope(config.file_group_scope),
+        )
     }
 
     /// Test-only builder accepting raw filter parameters.
@@ -839,11 +923,20 @@ impl std::fmt::Display for PlanStrategy {
                 .join(" -> ")
         };
 
-        write!(
-            f,
-            "{} -> {} -> {}",
-            file_filter_desc, self.grouping, group_filter_desc
-        )
+        match self.file_group_scope {
+            FileGroupScope::Partition => {
+                write!(
+                    f,
+                    "{} -> {} -> {}",
+                    file_filter_desc, self.grouping, group_filter_desc
+                )
+            }
+            FileGroupScope::Table => write!(
+                f,
+                "{} -> {:?} -> {} -> {}",
+                file_filter_desc, self.file_group_scope, self.grouping, group_filter_desc
+            ),
+        }
     }
 }
 
@@ -883,7 +976,10 @@ mod tests {
     use std::sync::{Arc, OnceLock};
 
     use super::*;
-    use crate::config::{CompactionPlanningConfig, SmallFilesConfigBuilder};
+    use crate::config::{
+        CompactionPlanningConfig, FileGroupScope, FilesWithDeletesConfigBuilder,
+        SmallFilesConfigBuilder,
+    };
     static TEST_SCHEMA: OnceLock<Arc<iceberg::spec::Schema>> = OnceLock::new();
 
     fn get_test_schema() -> Arc<iceberg::spec::Schema> {
@@ -1716,7 +1812,7 @@ mod tests {
 
         // Test Single variant
         let single_enum = GroupingStrategyEnum::Single(SingleGroupingStrategy);
-        let groups = single_enum.group_files(data_files.clone().into_iter());
+        let groups = single_enum.group_files(data_files.clone());
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].data_file_count, 2);
         assert_eq!(single_enum.to_string(), "SingleGrouping");
@@ -1727,20 +1823,20 @@ mod tests {
                 .size(20 * 1024 * 1024)
                 .build(),
         ];
-        let single_file_groups = single_enum.group_files(single.into_iter());
+        let single_file_groups = single_enum.group_files(single);
         assert_eq!(single_file_groups.len(), 1);
         assert_eq!(single_file_groups[0].data_file_count, 1);
         TestUtils::assert_paths_eq(&["single.parquet"], &single_file_groups[0].data_files);
 
         // Empty input
         let empty_files: Vec<FileScanTask> = vec![];
-        let single_empty_groups = single_enum.group_files(empty_files.into_iter());
+        let single_empty_groups = single_enum.group_files(empty_files);
         assert_eq!(single_empty_groups.len(), 0);
 
         // Test BinPack variant
         let binpack_enum =
             GroupingStrategyEnum::BinPack(BinPackGroupingStrategy::new(20 * 1024 * 1024));
-        let binpack_groups = binpack_enum.group_files(data_files.into_iter());
+        let binpack_groups = binpack_enum.group_files(data_files);
         assert!(!binpack_groups.is_empty());
         assert_eq!(binpack_enum.to_string(), "BinPackGrouping[target=20MB]");
     }
@@ -2699,6 +2795,155 @@ mod tests {
             iceberg::spec::Literal::Primitive(iceberg::spec::PrimitiveLiteral::Int(bucket_value)),
         )];
         iceberg::spec::Struct::from_iter(fields)
+    }
+
+    fn partitioned_file(name: &str, partition_num: i32) -> FileScanTask {
+        TestFileBuilder::new(name)
+            .size(1024 * 1024)
+            .with_partition(create_partition_value(partition_num))
+            .with_schema(get_test_schema_with_partition())
+            .build()
+    }
+
+    fn delete_heavy_partitioned_file(name: &str, partition_num: i32) -> FileScanTask {
+        TestFileBuilder::new(name)
+            .size(1024 * 1024)
+            .with_deletes()
+            .with_partition(create_partition_value(partition_num))
+            .with_schema(get_test_schema_with_partition())
+            .build()
+    }
+
+    fn min_file_count_filter(min_file_count: usize) -> crate::config::GroupFilters {
+        crate::config::GroupFilters {
+            min_group_file_count: Some(min_file_count),
+            min_group_size_bytes: None,
+        }
+    }
+
+    #[test]
+    fn test_grouping_strategy_enum_group_files_keeps_partition_scope() {
+        let files = vec![
+            partitioned_file("p0_file1.parquet", 0),
+            partitioned_file("p0_file2.parquet", 0),
+            partitioned_file("p1_file1.parquet", 1),
+            partitioned_file("p2_file1.parquet", 2),
+            partitioned_file("p2_file2.parquet", 2),
+        ];
+
+        let strategy = GroupingStrategyEnum::Single(SingleGroupingStrategy);
+        let groups = strategy.group_files(files);
+        let mut file_counts = groups
+            .iter()
+            .map(|group| group.data_file_count)
+            .collect::<Vec<_>>();
+        file_counts.sort_unstable();
+
+        assert_eq!(file_counts, vec![1, 2, 2]);
+    }
+
+    #[test]
+    fn test_table_scope_single_grouping_does_not_split_partitions() {
+        let files = vec![
+            partitioned_file("p0_file1.parquet", 0),
+            partitioned_file("p0_file2.parquet", 0),
+            partitioned_file("p1_file1.parquet", 1),
+            partitioned_file("p2_file1.parquet", 2),
+            partitioned_file("p2_file2.parquet", 2),
+        ];
+
+        let strategy = PlanStrategy::new_with_options(
+            PlanStrategyOptions::new(
+                vec![],
+                GroupingStrategyEnum::Single(SingleGroupingStrategy),
+                vec![],
+            )
+            .with_file_group_scope(FileGroupScope::Table),
+        );
+        let groups = strategy.group_files(files);
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].data_file_count, 5);
+    }
+
+    #[test]
+    fn test_small_files_table_scope_applies_group_filter_across_partitions() {
+        let files = vec![
+            partitioned_file("p0_file1.parquet", 0),
+            partitioned_file("p0_file2.parquet", 0),
+            partitioned_file("p1_file1.parquet", 1),
+            partitioned_file("p1_file2.parquet", 1),
+            partitioned_file("p2_file1.parquet", 2),
+        ];
+        let group_filters = min_file_count_filter(5);
+        let table_scope_config = SmallFilesConfigBuilder::default()
+            .grouping_strategy(GroupingStrategy::Single)
+            .file_group_scope(FileGroupScope::Table)
+            .group_filters(group_filters.clone())
+            .build()
+            .unwrap();
+        let partition_scope_config = SmallFilesConfigBuilder::default()
+            .grouping_strategy(GroupingStrategy::Single)
+            .group_filters(group_filters)
+            .build()
+            .unwrap();
+
+        let table_scope_groups = PlanStrategy::from_small_files(&table_scope_config)
+            .execute(
+                files.clone(),
+                &CompactionPlanningConfig::SmallFiles(table_scope_config),
+            )
+            .unwrap();
+        let partition_scope_groups = PlanStrategy::from_small_files(&partition_scope_config)
+            .execute(
+                files,
+                &CompactionPlanningConfig::SmallFiles(partition_scope_config),
+            )
+            .unwrap();
+
+        assert_eq!(table_scope_groups.len(), 1);
+        assert_eq!(table_scope_groups[0].data_file_count, 5);
+        assert_eq!(partition_scope_groups.len(), 0);
+    }
+
+    #[test]
+    fn test_files_with_deletes_table_scope_applies_group_filter_across_partitions() {
+        let files = vec![
+            delete_heavy_partitioned_file("p0_file1.parquet", 0),
+            delete_heavy_partitioned_file("p1_file1.parquet", 1),
+            delete_heavy_partitioned_file("p2_file1.parquet", 2),
+        ];
+        let group_filters = min_file_count_filter(3);
+        let table_scope_config = FilesWithDeletesConfigBuilder::default()
+            .grouping_strategy(GroupingStrategy::Single)
+            .file_group_scope(FileGroupScope::Table)
+            .min_delete_file_count_threshold(1_usize)
+            .group_filters(group_filters.clone())
+            .build()
+            .unwrap();
+        let partition_scope_config = FilesWithDeletesConfigBuilder::default()
+            .grouping_strategy(GroupingStrategy::Single)
+            .min_delete_file_count_threshold(1_usize)
+            .group_filters(group_filters)
+            .build()
+            .unwrap();
+
+        let table_scope_groups = PlanStrategy::from_files_with_deletes(&table_scope_config)
+            .execute(
+                files.clone(),
+                &CompactionPlanningConfig::FilesWithDeletes(table_scope_config),
+            )
+            .unwrap();
+        let partition_scope_groups = PlanStrategy::from_files_with_deletes(&partition_scope_config)
+            .execute(
+                files,
+                &CompactionPlanningConfig::FilesWithDeletes(partition_scope_config),
+            )
+            .unwrap();
+
+        assert_eq!(table_scope_groups.len(), 1);
+        assert_eq!(table_scope_groups[0].data_file_count, 3);
+        assert_eq!(partition_scope_groups.len(), 0);
     }
 
     #[test]

--- a/docs/compaction-strategy-contract.md
+++ b/docs/compaction-strategy-contract.md
@@ -15,7 +15,8 @@ This document describes the current design boundaries of `Full`, `SmallFiles`, `
 - `data file`: a `FileScanTask` where `data_file_content == Data`
 - `delete-heavy`: when `min_delete_file_count_threshold > 0`, `deletes.len() >= min_delete_file_count_threshold`
 - `candidate set`: the set of data files that a strategy is allowed to include in compaction
-- `group gating`: group-level thresholds used to avoid frequent small rewrites
+- `file group scope`: the boundary used before applying the grouping strategy; `Partition` keeps groups within one Iceberg partition, while `Table` lets the strategy group all selected files together
+- `group gating`: group-level thresholds used to avoid frequent small rewrites; these thresholds are applied after `file group scope` and `grouping_strategy`
 - `plan budget`: the maximum number of plans that `Auto` is allowed to execute in a single run
 - `fixed-point rewrite`: for the input files rewritten in the current run, the newly committed snapshot should cause them to leave that strategy's candidate set
 
@@ -25,6 +26,8 @@ This document describes the current design boundaries of `Full`, `SmallFiles`, `
 
 - Intended use: explicit/manual full-table rewrite
 - Candidate set: all data files
+- Default file group scope: `Partition`
+- Use `FileGroupScope::Table` with `GroupingStrategy::Single` when the full-table rewrite must be planned as one file group
 - Does not need to be fixed-point
 - Is not used as an `Auto` fallback
 
@@ -32,6 +35,8 @@ This document describes the current design boundaries of `Full`, `SmallFiles`, `
 
 - Intended use: append-only or general size-based compaction
 - Candidate set: `file_size < small_file_threshold_bytes`
+- Default file group scope: `Partition`
+- Explicit `Table` scope is allowed for manual planning, but group gating then evaluates groups across all selected partitions instead of per partition
 - May use `group_filters` for group gating
 - Must be fixed-point: rewritten input files that reach the target threshold should leave the candidate set in the newly committed snapshot
 
@@ -39,6 +44,8 @@ This document describes the current design boundaries of `Full`, `SmallFiles`, `
 
 - Intended use: timely cleanup of delete-heavy files
 - Candidate set: `deletes.len() >= min_delete_file_count_threshold`
+- Default file group scope: `Partition`
+- Explicit `Table` scope is allowed for manual planning, but group gating then evaluates groups across all selected partitions instead of per partition
 - May use `group_filters` for group gating
 - `Auto` does not rewrite or override caller-provided group gating for this strategy
 - Under `Auto`, `min_delete_file_count_threshold == 0` disables delete-heavy detection and therefore disables this candidate
@@ -65,6 +72,7 @@ It then applies the following fixed decision order:
 Design focus:
 
 - Only choose localized rewrite strategies
+- Keep auto-generated plans at `Partition` file group scope
 - Apply a uniform budget to the final selected plan set
 
 ## Why `Auto` Does Not Fall Back to `Full`


### PR DESCRIPTION
## Summary
- add FileGroupScope to control whether grouping is partition-scoped or table-scoped
- keep existing partition-scoped defaults and keep Auto-generated plans partition-scoped
- document the scope contract and add tests for default partition scope plus Full + Single + Table behavior

## Tests
- cargo test -p iceberg-compaction-core file_selection::strategy -- --nocapture
- cargo test -p iceberg-compaction-core
- make check