### PR TITLE
chore: bump iceberg-rust to fc5d182c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c034b19105fa0f540256fbe4859be8121c5c0551#c034b19105fa0f540256fbe4859be8121c5c0551"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fc5d182c9fe407bebade5a771c76350b7efefd50#fc5d182c9fe407bebade5a771c76350b7efefd50"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c034b19105fa0f540256fbe4859be8121c5c0551#c034b19105fa0f540256fbe4859be8121c5c0551"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fc5d182c9fe407bebade5a771c76350b7efefd50#fc5d182c9fe407bebade5a771c76350b7efefd50"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c034b19105fa0f540256fbe4859be8121c5c0551#c034b19105fa0f540256fbe4859be8121c5c0551"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fc5d182c9fe407bebade5a771c76350b7efefd50#fc5d182c9fe407bebade5a771c76350b7efefd50"
 dependencies = [
  "async-trait",
  "base64",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c034b19105fa0f540256fbe4859be8121c5c0551#c034b19105fa0f540256fbe4859be8121c5c0551"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fc5d182c9fe407bebade5a771c76350b7efefd50#fc5d182c9fe407bebade5a771c76350b7efefd50"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ datafusion = "53.0"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c034b19105fa0f540256fbe4859be8121c5c0551", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c034b19105fa0f540256fbe4859be8121c5c0551" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c034b19105fa0f540256fbe4859be8121c5c0551" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c034b19105fa0f540256fbe4859be8121c5c0551" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fc5d182c9fe407bebade5a771c76350b7efefd50", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fc5d182c9fe407bebade5a771c76350b7efefd50" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fc5d182c9fe407bebade5a771c76350b7efefd50" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fc5d182c9fe407bebade5a771c76350b7efefd50" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c034b19105fa0f540256fbe4859be8121c5c0551" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fc5d182c9fe407bebade5a771c76350b7efefd50" }
 
 parquet = { version = "58.1", features = ["async"] }
 port_scanner = "0.1.5"


### PR DESCRIPTION
## Summary
- bump iceberg-rust workspace dependencies to fc5d182c9fe407bebade5a771c76350b7efefd50

## Testing
- make check