### PR TITLE
chore: add CODEOWNERS (synced with iceberg-rust)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Code owners for iceberg-compaction.
 # Automatically request reviews from these users on all PRs.
 # See https://docs.github.com/articles/about-code-owners
-* @mwylde @nagraham @Li0k @chenzl25 @vovacf201 @netgusto
+* @mwylde @nagraham @Li0k @chenzl25 @vovacf201 @netgusto @agaddis02

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Code owners for iceberg-compaction.
 # Automatically request reviews from these users on all PRs.
 # See https://docs.github.com/articles/about-code-owners
-* @netgusto
+* @mwylde @nagraham @Li0k @chenzl25 @vovacf201 @netgusto

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners for iceberg-compaction.
+# Automatically request reviews from these users on all PRs.
+# See https://docs.github.com/articles/about-code-owners
+* @netgusto


### PR DESCRIPTION
## Summary
Adds a `.github/CODEOWNERS` (none existed before) so the listed users are auto-requested for review on all PRs.

Owner list (identical to `risingwavelabs/iceberg-rust`, see risingwavelabs/iceberg-rust#176):
```
* @mwylde @nagraham @Li0k @chenzl25 @vovacf201 @netgusto @agaddis02
```

The two repos are kept in sync with the same owner list.