### PR TITLE
chore: bump iceberg-rust to 9eb095f5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=a967045135abf591b20d2584120ea48b8bfdebd3#a967045135abf591b20d2584120ea48b8bfdebd3"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=9eb095f533a120d807ace0824826dde9b5bcf3e1#9eb095f533a120d807ace0824826dde9b5bcf3e1"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=a967045135abf591b20d2584120ea48b8bfdebd3#a967045135abf591b20d2584120ea48b8bfdebd3"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=9eb095f533a120d807ace0824826dde9b5bcf3e1#9eb095f533a120d807ace0824826dde9b5bcf3e1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=a967045135abf591b20d2584120ea48b8bfdebd3#a967045135abf591b20d2584120ea48b8bfdebd3"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=9eb095f533a120d807ace0824826dde9b5bcf3e1#9eb095f533a120d807ace0824826dde9b5bcf3e1"
 dependencies = [
  "async-trait",
  "base64",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=a967045135abf591b20d2584120ea48b8bfdebd3#a967045135abf591b20d2584120ea48b8bfdebd3"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=9eb095f533a120d807ace0824826dde9b5bcf3e1#9eb095f533a120d807ace0824826dde9b5bcf3e1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ datafusion = "53.0"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "a967045135abf591b20d2584120ea48b8bfdebd3", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "a967045135abf591b20d2584120ea48b8bfdebd3" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "a967045135abf591b20d2584120ea48b8bfdebd3" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "a967045135abf591b20d2584120ea48b8bfdebd3" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "9eb095f533a120d807ace0824826dde9b5bcf3e1", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "9eb095f533a120d807ace0824826dde9b5bcf3e1" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "9eb095f533a120d807ace0824826dde9b5bcf3e1" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "9eb095f533a120d807ace0824826dde9b5bcf3e1" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "a967045135abf591b20d2584120ea48b8bfdebd3" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "9eb095f533a120d807ace0824826dde9b5bcf3e1" }
 
 parquet = { version = "58.1", features = ["async"] }
 port_scanner = "0.1.5"


### PR DESCRIPTION
## Summary
- bump iceberg-rust workspace dependencies to 9eb095f533a120d807ace0824826dde9b5bcf3e1 (branch `dev_rebase_main_20260303`)
- no source changes required; compiles cleanly against the new rev

## Testing
- make check
- make build