### PR TITLE
chore: bump iceberg-rust to d9575b8c (variant support)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6420a9ae8fa02502a1eb54fe55df649b1e254e81#6420a9ae8fa02502a1eb54fe55df649b1e254e81"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7e63517c3f130f1230f35d6f41b5d2795349cf3e#7e63517c3f130f1230f35d6f41b5d2795349cf3e"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6420a9ae8fa02502a1eb54fe55df649b1e254e81#6420a9ae8fa02502a1eb54fe55df649b1e254e81"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7e63517c3f130f1230f35d6f41b5d2795349cf3e#7e63517c3f130f1230f35d6f41b5d2795349cf3e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6420a9ae8fa02502a1eb54fe55df649b1e254e81#6420a9ae8fa02502a1eb54fe55df649b1e254e81"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7e63517c3f130f1230f35d6f41b5d2795349cf3e#7e63517c3f130f1230f35d6f41b5d2795349cf3e"
 dependencies = [
  "async-trait",
  "base64",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6420a9ae8fa02502a1eb54fe55df649b1e254e81#6420a9ae8fa02502a1eb54fe55df649b1e254e81"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7e63517c3f130f1230f35d6f41b5d2795349cf3e#7e63517c3f130f1230f35d6f41b5d2795349cf3e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=9806a3e9a796fee65be2bb95b656057f8a1ffb89#9806a3e9a796fee65be2bb95b656057f8a1ffb89"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6420a9ae8fa02502a1eb54fe55df649b1e254e81#6420a9ae8fa02502a1eb54fe55df649b1e254e81"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=9806a3e9a796fee65be2bb95b656057f8a1ffb89#9806a3e9a796fee65be2bb95b656057f8a1ffb89"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6420a9ae8fa02502a1eb54fe55df649b1e254e81#6420a9ae8fa02502a1eb54fe55df649b1e254e81"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=9806a3e9a796fee65be2bb95b656057f8a1ffb89#9806a3e9a796fee65be2bb95b656057f8a1ffb89"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6420a9ae8fa02502a1eb54fe55df649b1e254e81#6420a9ae8fa02502a1eb54fe55df649b1e254e81"
 dependencies = [
  "async-trait",
  "base64",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=9806a3e9a796fee65be2bb95b656057f8a1ffb89#9806a3e9a796fee65be2bb95b656057f8a1ffb89"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6420a9ae8fa02502a1eb54fe55df649b1e254e81#6420a9ae8fa02502a1eb54fe55df649b1e254e81"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d9575b8cac34b307d6857d7ef326ef0cfa7f8912#d9575b8cac34b307d6857d7ef326ef0cfa7f8912"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=9806a3e9a796fee65be2bb95b656057f8a1ffb89#9806a3e9a796fee65be2bb95b656057f8a1ffb89"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d9575b8cac34b307d6857d7ef326ef0cfa7f8912#d9575b8cac34b307d6857d7ef326ef0cfa7f8912"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=9806a3e9a796fee65be2bb95b656057f8a1ffb89#9806a3e9a796fee65be2bb95b656057f8a1ffb89"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d9575b8cac34b307d6857d7ef326ef0cfa7f8912#d9575b8cac34b307d6857d7ef326ef0cfa7f8912"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=9806a3e9a796fee65be2bb95b656057f8a1ffb89#9806a3e9a796fee65be2bb95b656057f8a1ffb89"
 dependencies = [
  "async-trait",
  "base64",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d9575b8cac34b307d6857d7ef326ef0cfa7f8912#d9575b8cac34b307d6857d7ef326ef0cfa7f8912"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=9806a3e9a796fee65be2bb95b656057f8a1ffb89#9806a3e9a796fee65be2bb95b656057f8a1ffb89"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3756,6 +3756,9 @@ dependencies = [
  "num-integer",
  "num-traits",
  "object_store",
+ "parquet-variant",
+ "parquet-variant-compute",
+ "parquet-variant-json",
  "paste",
  "seq-macro",
  "simdutf8",
@@ -3764,6 +3767,51 @@ dependencies = [
  "tokio",
  "twox-hash",
  "zstd",
+]
+
+[[package]]
+name = "parquet-variant"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf493f3c9ddd984d0efb019f67343e4aa4bab893931f6a14b82083065dc3d28"
+dependencies = [
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.13.0",
+ "simdutf8",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-compute"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac038d46a503a7d563b4f5df5802c4315d5343d009feab195d15ac512b4cb27"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.13.0",
+ "parquet-variant",
+ "parquet-variant-json",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-json"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015a09c2ffe5108766c7c1235c307b8a3c2ea64eca38455ba1a7f3a7f32f16e2"
+dependencies = [
+ "arrow-schema",
+ "base64",
+ "chrono",
+ "parquet-variant",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=a967045135abf591b20d2584120ea48b8bfdebd3#a967045135abf591b20d2584120ea48b8bfdebd3"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d9575b8cac34b307d6857d7ef326ef0cfa7f8912#d9575b8cac34b307d6857d7ef326ef0cfa7f8912"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=a967045135abf591b20d2584120ea48b8bfdebd3#a967045135abf591b20d2584120ea48b8bfdebd3"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d9575b8cac34b307d6857d7ef326ef0cfa7f8912#d9575b8cac34b307d6857d7ef326ef0cfa7f8912"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=a967045135abf591b20d2584120ea48b8bfdebd3#a967045135abf591b20d2584120ea48b8bfdebd3"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d9575b8cac34b307d6857d7ef326ef0cfa7f8912#d9575b8cac34b307d6857d7ef326ef0cfa7f8912"
 dependencies = [
  "async-trait",
  "base64",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=a967045135abf591b20d2584120ea48b8bfdebd3#a967045135abf591b20d2584120ea48b8bfdebd3"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=d9575b8cac34b307d6857d7ef326ef0cfa7f8912#d9575b8cac34b307d6857d7ef326ef0cfa7f8912"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ datafusion = "53.0"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6420a9ae8fa02502a1eb54fe55df649b1e254e81", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6420a9ae8fa02502a1eb54fe55df649b1e254e81" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6420a9ae8fa02502a1eb54fe55df649b1e254e81" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6420a9ae8fa02502a1eb54fe55df649b1e254e81" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7e63517c3f130f1230f35d6f41b5d2795349cf3e", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7e63517c3f130f1230f35d6f41b5d2795349cf3e" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7e63517c3f130f1230f35d6f41b5d2795349cf3e" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7e63517c3f130f1230f35d6f41b5d2795349cf3e" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6420a9ae8fa02502a1eb54fe55df649b1e254e81" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7e63517c3f130f1230f35d6f41b5d2795349cf3e" }
 
 parquet = { version = "58.1", features = ["async"] }
 port_scanner = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ datafusion = "53.0"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "9806a3e9a796fee65be2bb95b656057f8a1ffb89", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "9806a3e9a796fee65be2bb95b656057f8a1ffb89" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "9806a3e9a796fee65be2bb95b656057f8a1ffb89" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "9806a3e9a796fee65be2bb95b656057f8a1ffb89" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6420a9ae8fa02502a1eb54fe55df649b1e254e81", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6420a9ae8fa02502a1eb54fe55df649b1e254e81" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6420a9ae8fa02502a1eb54fe55df649b1e254e81" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6420a9ae8fa02502a1eb54fe55df649b1e254e81" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "9806a3e9a796fee65be2bb95b656057f8a1ffb89" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6420a9ae8fa02502a1eb54fe55df649b1e254e81" }
 
 parquet = { version = "58.1", features = ["async"] }
 port_scanner = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ datafusion = "53.0"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "a967045135abf591b20d2584120ea48b8bfdebd3", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "a967045135abf591b20d2584120ea48b8bfdebd3" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "a967045135abf591b20d2584120ea48b8bfdebd3" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "a967045135abf591b20d2584120ea48b8bfdebd3" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d9575b8cac34b307d6857d7ef326ef0cfa7f8912", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d9575b8cac34b307d6857d7ef326ef0cfa7f8912" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d9575b8cac34b307d6857d7ef326ef0cfa7f8912" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d9575b8cac34b307d6857d7ef326ef0cfa7f8912" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "a967045135abf591b20d2584120ea48b8bfdebd3" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d9575b8cac34b307d6857d7ef326ef0cfa7f8912" }
 
 parquet = { version = "58.1", features = ["async"] }
 port_scanner = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ datafusion = "53.0"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d9575b8cac34b307d6857d7ef326ef0cfa7f8912", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d9575b8cac34b307d6857d7ef326ef0cfa7f8912" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d9575b8cac34b307d6857d7ef326ef0cfa7f8912" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d9575b8cac34b307d6857d7ef326ef0cfa7f8912" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "9806a3e9a796fee65be2bb95b656057f8a1ffb89", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "9806a3e9a796fee65be2bb95b656057f8a1ffb89" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "9806a3e9a796fee65be2bb95b656057f8a1ffb89" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "9806a3e9a796fee65be2bb95b656057f8a1ffb89" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "d9575b8cac34b307d6857d7ef326ef0cfa7f8912" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "9806a3e9a796fee65be2bb95b656057f8a1ffb89" }
 
 parquet = { version = "58.1", features = ["async"] }
 port_scanner = "0.1.5"


### PR DESCRIPTION
Bumps the pinned risingwavelabs/iceberg-rust rev from a9670451 to 6420a9ae.

6420a9ae is the head of risingwavelabs/iceberg-rust#145 (Iceberg VARIANT read support, rebased on the current fork main a9670451-lineage). It is a superset of the currently pinned rev, so this is a no-op for existing compaction behavior — verified with `cargo check --workspace` and `cargo test --workspace --lib` (133 tests pass, no source changes needed).

Needed by risingwavelabs/risingwave#25165 so the workspace and iceberg-compaction-core resolve to a single `iceberg` crate instead of two conflicting copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)