### PR TITLE
chore: bump iceberg-rust to 0d9e873c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7e63517c3f130f1230f35d6f41b5d2795349cf3e#7e63517c3f130f1230f35d6f41b5d2795349cf3e"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=0d9e873c1262158ef37cce2e4913b8545e8c7b24#0d9e873c1262158ef37cce2e4913b8545e8c7b24"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7e63517c3f130f1230f35d6f41b5d2795349cf3e#7e63517c3f130f1230f35d6f41b5d2795349cf3e"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=0d9e873c1262158ef37cce2e4913b8545e8c7b24#0d9e873c1262158ef37cce2e4913b8545e8c7b24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7e63517c3f130f1230f35d6f41b5d2795349cf3e#7e63517c3f130f1230f35d6f41b5d2795349cf3e"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=0d9e873c1262158ef37cce2e4913b8545e8c7b24#0d9e873c1262158ef37cce2e4913b8545e8c7b24"
 dependencies = [
  "async-trait",
  "base64",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7e63517c3f130f1230f35d6f41b5d2795349cf3e#7e63517c3f130f1230f35d6f41b5d2795349cf3e"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=0d9e873c1262158ef37cce2e4913b8545e8c7b24#0d9e873c1262158ef37cce2e4913b8545e8c7b24"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ datafusion = "53.0"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7e63517c3f130f1230f35d6f41b5d2795349cf3e", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7e63517c3f130f1230f35d6f41b5d2795349cf3e" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7e63517c3f130f1230f35d6f41b5d2795349cf3e" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7e63517c3f130f1230f35d6f41b5d2795349cf3e" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "0d9e873c1262158ef37cce2e4913b8545e8c7b24", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "0d9e873c1262158ef37cce2e4913b8545e8c7b24" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "0d9e873c1262158ef37cce2e4913b8545e8c7b24" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "0d9e873c1262158ef37cce2e4913b8545e8c7b24" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7e63517c3f130f1230f35d6f41b5d2795349cf3e" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "0d9e873c1262158ef37cce2e4913b8545e8c7b24" }
 
 parquet = { version = "58.1", features = ["async"] }
 port_scanner = "0.1.5"


### PR DESCRIPTION
Advances the pinned `risingwavelabs/iceberg-rust` rev (tracked branch `dev_rebase_main_20260303`) from `7e63517c` to `0d9e873c`.

### Commits pulled in (`7e63517c..0d9e873c`, 5)
- fix: rewrite/overwrite transactions mishandle DELETE manifests (#179)
- refactor: unify overwrite & rewrite txn (#182)
- Improve `RewriteManifestsAction` to reuse rewritten manifests on conflict retry (#181)
- perf(iceberg): stream manifest loading in orphan file removal (#177)
- chore: code owners updates (#183)

### Changes
- Updated all 5 iceberg-rust `rev` pins in `Cargo.toml`.
- Regenerated `Cargo.lock` (only the iceberg git sources changed).

### Validation
- `make check` (fmt + clippy `-D warnings` + taplo): clean.
- `cargo test -p iceberg-compaction-core --lib`: 132 passed.
- Integration tests (Docker/MinIO) left to CI.