### PR TITLE
chore: bump iceberg-rust to 0b65d716

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=08a18f4116382e7c9691d63a91f1b0a0342a40b1#08a18f4116382e7c9691d63a91f1b0a0342a40b1"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=0b65d716de88000b6bb8e131dc67b50ef0b7f444#0b65d716de88000b6bb8e131dc67b50ef0b7f444"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=08a18f4116382e7c9691d63a91f1b0a0342a40b1#08a18f4116382e7c9691d63a91f1b0a0342a40b1"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=0b65d716de88000b6bb8e131dc67b50ef0b7f444#0b65d716de88000b6bb8e131dc67b50ef0b7f444"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=08a18f4116382e7c9691d63a91f1b0a0342a40b1#08a18f4116382e7c9691d63a91f1b0a0342a40b1"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=0b65d716de88000b6bb8e131dc67b50ef0b7f444#0b65d716de88000b6bb8e131dc67b50ef0b7f444"
 dependencies = [
  "async-trait",
  "base64",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=08a18f4116382e7c9691d63a91f1b0a0342a40b1#08a18f4116382e7c9691d63a91f1b0a0342a40b1"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=0b65d716de88000b6bb8e131dc67b50ef0b7f444#0b65d716de88000b6bb8e131dc67b50ef0b7f444"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ datafusion = "53.0"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "08a18f4116382e7c9691d63a91f1b0a0342a40b1", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "08a18f4116382e7c9691d63a91f1b0a0342a40b1" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "08a18f4116382e7c9691d63a91f1b0a0342a40b1" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "08a18f4116382e7c9691d63a91f1b0a0342a40b1" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "0b65d716de88000b6bb8e131dc67b50ef0b7f444", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "0b65d716de88000b6bb8e131dc67b50ef0b7f444" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "0b65d716de88000b6bb8e131dc67b50ef0b7f444" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "0b65d716de88000b6bb8e131dc67b50ef0b7f444" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "08a18f4116382e7c9691d63a91f1b0a0342a40b1" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "0b65d716de88000b6bb8e131dc67b50ef0b7f444" }
 
 parquet = { version = "58.1", features = ["async"] }
 port_scanner = "0.1.5"


### PR DESCRIPTION
Bumps the pinned `iceberg-rust` rev from `08a18f4` → `0b65d716` (all five `iceberg*` deps in `Cargo.toml` + `Cargo.lock`).

`0b65d716` is the merge of [risingwavelabs/iceberg-rust#185](https://github.com/risingwavelabs/iceberg-rust/pull/185) into `dev_rebase_main_20260303` — the direct child of the current pin `08a18f4` — which:
- **bounds rewrite-manifests memory** by flushing sealed manifest writers incrementally inside the load stream instead of buffering every output entry until the end (prevents OOM on large single-key / unpartitioned rewrites), and
- **calibrates `estimate_manifest_entry_size`** so size-bounded manifests land near the configured target instead of ~0.6×.

No API changes affecting `iceberg-compaction-core`. `cargo check --workspace` is clean.