### PR TITLE
chore: bump iceberg-rust to edf72a59

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=0b65d716de88000b6bb8e131dc67b50ef0b7f444#0b65d716de88000b6bb8e131dc67b50ef0b7f444"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=edf72a59b6b9fd4877192ac5f019119ba4379029#edf72a59b6b9fd4877192ac5f019119ba4379029"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=0b65d716de88000b6bb8e131dc67b50ef0b7f444#0b65d716de88000b6bb8e131dc67b50ef0b7f444"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=edf72a59b6b9fd4877192ac5f019119ba4379029#edf72a59b6b9fd4877192ac5f019119ba4379029"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=0b65d716de88000b6bb8e131dc67b50ef0b7f444#0b65d716de88000b6bb8e131dc67b50ef0b7f444"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=edf72a59b6b9fd4877192ac5f019119ba4379029#edf72a59b6b9fd4877192ac5f019119ba4379029"
 dependencies = [
  "async-trait",
  "base64",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=0b65d716de88000b6bb8e131dc67b50ef0b7f444#0b65d716de88000b6bb8e131dc67b50ef0b7f444"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=edf72a59b6b9fd4877192ac5f019119ba4379029#edf72a59b6b9fd4877192ac5f019119ba4379029"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ datafusion = "53.0"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "0b65d716de88000b6bb8e131dc67b50ef0b7f444", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "0b65d716de88000b6bb8e131dc67b50ef0b7f444" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "0b65d716de88000b6bb8e131dc67b50ef0b7f444" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "0b65d716de88000b6bb8e131dc67b50ef0b7f444" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "edf72a59b6b9fd4877192ac5f019119ba4379029", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "edf72a59b6b9fd4877192ac5f019119ba4379029" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "edf72a59b6b9fd4877192ac5f019119ba4379029" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "edf72a59b6b9fd4877192ac5f019119ba4379029" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "0b65d716de88000b6bb8e131dc67b50ef0b7f444" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "edf72a59b6b9fd4877192ac5f019119ba4379029" }
 
 parquet = { version = "58.1", features = ["async"] }
 port_scanner = "0.1.5"


### PR DESCRIPTION
Bumps `iceberg-rust` from `0b65d716` to `edf72a59` (one commit: risingwavelabs/iceberg-rust#190).

## What it fixes

`build_field_id_map` reports a Parquet file as having no field IDs as soon as a single
leaf lacks one, and the predicate path then fell back to position-based IDs
**unconditionally**. A variant column carries its field ID on the storage group while its
`metadata`/`value` leaves have none, so **any** table containing a variant took that
fallback — shifting every column after the variant by its leaf count.

For `(payload variant, a int, b int)` the fallback maps field ID 3 (`b`) to leaf 2 (`a`)
and field ID 2 (`a`) to leaf 1 (`payload.value`):

| query | expected | before |
|---|---|---|
| `where b = 200` | 1 row | **0 rows** (row filter and row-group stats both judged column `a`) |
| `where a = 2` | 1 row | `DataInvalid => Leave column 'a' in predicates isn't a root column in Parquet schema.` |

Projection was unaffected, so the corruption only appeared once a predicate was pushed
down. When the variant column happened to be last, position fallback coincidentally
aligned and everything looked fine.

The fix gates the position fallback on the file genuinely lacking IDs and otherwise
resolves through the Arrow schema, which skips ID-less leaves instead of shifting the
ones that carry an ID. It also covers the name-mapping branch.

## Why this repo needs it

RisingWave pins both `iceberg-compaction-core` and `iceberg-rust` and needs them on the
same `iceberg` rev to keep a single copy of the crates in the dependency graph.

## Testing

`cargo check --all-targets` clean; `cargo test --lib` → 132 + 5 passed, 0 failed.
