### PR TITLE
chore: bump iceberg-rust to ee489f56

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=edf72a59b6b9fd4877192ac5f019119ba4379029#edf72a59b6b9fd4877192ac5f019119ba4379029"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=ee489f56c29f030eb52f5b2f7509f954c952ca58#ee489f56c29f030eb52f5b2f7509f954c952ca58"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=edf72a59b6b9fd4877192ac5f019119ba4379029#edf72a59b6b9fd4877192ac5f019119ba4379029"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=ee489f56c29f030eb52f5b2f7509f954c952ca58#ee489f56c29f030eb52f5b2f7509f954c952ca58"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=edf72a59b6b9fd4877192ac5f019119ba4379029#edf72a59b6b9fd4877192ac5f019119ba4379029"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=ee489f56c29f030eb52f5b2f7509f954c952ca58#ee489f56c29f030eb52f5b2f7509f954c952ca58"
 dependencies = [
  "async-trait",
  "base64",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=edf72a59b6b9fd4877192ac5f019119ba4379029#edf72a59b6b9fd4877192ac5f019119ba4379029"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=ee489f56c29f030eb52f5b2f7509f954c952ca58#ee489f56c29f030eb52f5b2f7509f954c952ca58"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ datafusion = "53.0"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "edf72a59b6b9fd4877192ac5f019119ba4379029", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "edf72a59b6b9fd4877192ac5f019119ba4379029" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "edf72a59b6b9fd4877192ac5f019119ba4379029" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "edf72a59b6b9fd4877192ac5f019119ba4379029" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "ee489f56c29f030eb52f5b2f7509f954c952ca58", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "ee489f56c29f030eb52f5b2f7509f954c952ca58" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "ee489f56c29f030eb52f5b2f7509f954c952ca58" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "ee489f56c29f030eb52f5b2f7509f954c952ca58" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "edf72a59b6b9fd4877192ac5f019119ba4379029" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "ee489f56c29f030eb52f5b2f7509f954c952ca58" }
 
 parquet = { version = "58.1", features = ["async"] }
 port_scanner = "0.1.5"


### PR DESCRIPTION
Bumps the pinned `iceberg-rust` rev from `edf72a59` to `ee489f56`, picking up three fixes:

| Upstream PR | Change |
|---|---|
| risingwavelabs/iceberg-rust#186 | `fix(arrow)`: fail cleanly on truncated data files instead of panicking |
| risingwavelabs/iceberg-rust#187 | `fix(spec)`: decode truncated string metric bounds leniently |
| risingwavelabs/iceberg-rust#188 | `fix(iceberg)`: drop dangling deletion vectors when data files are rewritten |

## Why #188 matters here

`ManifestFilterManager` now implements the dangling-delete check that was previously a TODO (`// TODO: Add dangling delete vector check`). Compaction drives that code via `RewriteFilesAction` with `set_enable_delete_filter_manager(true)`, so until now **every compaction round left the input data files' deletion vectors live in the delete manifests forever**: they applied to nothing (a reader binds a DV to its data file by `referenced-data-file`, and that file was gone) but stayed *reachable*, which meant

- delete manifests grew monotonically with every rewrite,
- the Puffin files stayed pinned alive, so `expire_snapshots` could not reclaim them,
- scan planning kept loading delete entries that could never apply.

The only prior mitigation was the coarse sequence-number rule in `drop_delete_files_older_than`, which is opportunistic and cannot fire while any older data manifest survives.

The check is deliberately conservative — a delete is dropped only when it targets exactly one data file (`referenced-data-file` present) and that file is in the removed set, so equality deletes and multi-file position deletes are untouched. It is also per-*blob*, not per-path: several DVs can share one Puffin, so a dangling blob is never promoted to a path-level deletion, which would otherwise drop live DVs of untouched data files.

#186 and #187 harden the reader and metric-bound decoding against truncated data files, which this crate reads directly during compaction.

## Notes

- Lock regenerated with a targeted `cargo update -p iceberg` (8 lines), so the bump carries no unrelated dependency churn.
- No source changes needed — the new revision is API-compatible.

## Verification

On the pinned `nightly-2025-10-10` toolchain from `rust-toolchain.toml`:

- `make check-fmt` — pass
- `make check-clippy` (`cargo clippy --workspace --all-targets -- -D warnings`) — pass
- `cargo test --workspace --lib` — **139 passed, 0 failed**

Integration tests need Docker and are left to CI.