### PR TITLE
feat: fail the rewrite commit when deletes were added for files it replaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c#cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=02ab2a5af77431d8e42a4b016f02343a75b63e87#02ab2a5af77431d8e42a4b016f02343a75b63e87"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c#cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=02ab2a5af77431d8e42a4b016f02343a75b63e87#02ab2a5af77431d8e42a4b016f02343a75b63e87"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c#cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=02ab2a5af77431d8e42a4b016f02343a75b63e87#02ab2a5af77431d8e42a4b016f02343a75b63e87"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c#cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=02ab2a5af77431d8e42a4b016f02343a75b63e87#02ab2a5af77431d8e42a4b016f02343a75b63e87"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c#cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=02ab2a5af77431d8e42a4b016f02343a75b63e87#02ab2a5af77431d8e42a4b016f02343a75b63e87"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,16 @@ datafusion = "54.1"
 
 # Local workspace members
 futures = "0.3.17"
-# branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c" }
+# TEMPORARY: pinned to the head of risingwavelabs/iceberg-rust#202 (open, based on
+# dev_rebase_main_20260807) for `validate_from_snapshot_id`. Re-pin to the merge commit
+# on dev_rebase_main_20260807 once #202 lands. Not for merge as-is.
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "02ab2a5af77431d8e42a4b016f02343a75b63e87" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "02ab2a5af77431d8e42a4b016f02343a75b63e87" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "02ab2a5af77431d8e42a4b016f02343a75b63e87" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "02ab2a5af77431d8e42a4b016f02343a75b63e87" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c", features = [
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "02ab2a5af77431d8e42a4b016f02343a75b63e87" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "02ab2a5af77431d8e42a4b016f02343a75b63e87", features = [
     "opendal-s3",
 ] }
 

--- a/core/src/compaction/mod.rs
+++ b/core/src/compaction/mod.rs
@@ -1077,14 +1077,20 @@ impl CommitManager {
                         ));
                     }
                 } else {
+                    // No `validate_from_snapshot_id` here on purpose. This path deliberately does
+                    // *not* preserve the starting snapshot's sequence number, and that is precisely
+                    // what keeps pre-existing equality deletes applicable to the replacement files.
+                    // The validation refuses to promise anything without it rather than offer a
+                    // guarantee that only holds for position deletes, so requesting it here would
+                    // simply fail the commit. Concurrent-delete protection therefore requires
+                    // `use_starting_sequence_number`.
                     let mut action = txn
                         .rewrite_files()
                         .set_enable_delete_filter_manager(true)
                         .add_data_files(data_files)
                         .delete_files(delete_files)
                         .set_target_branch(to_branch.to_owned())
-                        .set_check_file_existence(true)
-                        .validate_from_snapshot_id(starting_snapshot_id);
+                        .set_check_file_existence(true);
                     if let Some(snapshot) = table.metadata().snapshot_for_ref(to_branch) {
                         action.set_snapshot_properties(custom_snapshot_properties(snapshot));
                     }

--- a/core/src/compaction/mod.rs
+++ b/core/src/compaction/mod.rs
@@ -1049,7 +1049,11 @@ impl CommitManager {
 
                 let txn = Transaction::new(&table);
 
-                // TODO: support validation of data files and delete files with starting snapshot before applying the rewrite
+                // The rewrite materialized the deletes that were visible at
+                // `starting_snapshot_id`. If another writer has added deletes for one of the data
+                // files being replaced since then, those deletes are not in the new files, and
+                // removing the old data file would retire them as dangling — resurrecting the rows
+                // they deleted. `validate_from_snapshot_id` turns that into a failed commit.
                 let mut rewrite_action = if use_starting_sequence_number {
                     // TODO: avoid retry if the snapshot_id is not found
                     if let Some(snapshot) = table.metadata().snapshot_by_id(starting_snapshot_id) {
@@ -1060,7 +1064,8 @@ impl CommitManager {
                             .delete_files(delete_files)
                             .set_target_branch(to_branch.to_owned())
                             .set_new_data_file_sequence_number(snapshot.sequence_number())
-                            .set_check_file_existence(true);
+                            .set_check_file_existence(true)
+                            .validate_from_snapshot_id(starting_snapshot_id);
                         action.set_snapshot_properties(custom_snapshot_properties(snapshot));
                         action
                     } else {
@@ -1078,7 +1083,8 @@ impl CommitManager {
                         .add_data_files(data_files)
                         .delete_files(delete_files)
                         .set_target_branch(to_branch.to_owned())
-                        .set_check_file_existence(true);
+                        .set_check_file_existence(true)
+                        .validate_from_snapshot_id(starting_snapshot_id);
                     if let Some(snapshot) = table.metadata().snapshot_for_ref(to_branch) {
                         action.set_snapshot_properties(custom_snapshot_properties(snapshot));
                     }

--- a/core/src/compaction/mod.rs
+++ b/core/src/compaction/mod.rs
@@ -1830,6 +1830,293 @@ mod tests {
             .build()
     }
 
+    /// Creates a V3 table, which is what deletion vectors require.
+    async fn create_v3_test_env() -> TestEnv {
+        let temp_dir = TempDir::new().unwrap();
+        let warehouse_location = temp_dir.path().to_str().unwrap().to_owned();
+        let catalog = Arc::new(
+            MemoryCatalogBuilder::default()
+                .load(
+                    "memory",
+                    HashMap::from([(
+                        MEMORY_CATALOG_WAREHOUSE.to_owned(),
+                        warehouse_location.clone(),
+                    )]),
+                )
+                .await
+                .unwrap(),
+        );
+
+        let namespace_ident = NamespaceIdent::new("test_namespace".into());
+        create_namespace(catalog.as_ref(), &namespace_ident).await;
+
+        let table_ident = TableIdent::new(namespace_ident.clone(), "test_table_v3".into());
+        catalog
+            .create_table(
+                &table_ident.namespace,
+                TableCreation::builder()
+                    .name(table_ident.name().into())
+                    .schema(simple_table_schema())
+                    .format_version(iceberg::spec::FormatVersion::V3)
+                    .build(),
+            )
+            .await
+            .unwrap();
+
+        let table = catalog.load_table(&table_ident).await.unwrap();
+        assert_eq!(
+            table.metadata().format_version(),
+            iceberg::spec::FormatVersion::V3,
+            "the fixture must actually be V3, or deletion vectors are not exercised"
+        );
+
+        TestEnv {
+            temp_dir,
+            warehouse_location,
+            catalog,
+            table_ident,
+            table,
+        }
+    }
+
+    /// Writes **one** Puffin file containing a deletion vector for each entry in `deletes`, and
+    /// returns the delete-file entries that reference the blobs inside it.
+    ///
+    /// A single Puffin carrying several deletion vectors is the case that distinguishes a correct
+    /// implementation from a broken one: anything that reasons about deletion vectors by *file path*
+    /// rather than by blob will treat these as one unit, and retiring one will silently retire the
+    /// other — resurrecting rows. Note `iceberg-rust`'s own `DeletionVectorWriter` emits one Puffin
+    /// per data file, so this shape only arises from other engines and has to be built by hand.
+    async fn write_shared_puffin_deletion_vectors(
+        table: &Table,
+        warehouse_location: &str,
+        deletes: &[(String, u64)],
+    ) -> Vec<DataFile> {
+        use std::collections::HashMap as StdHashMap;
+
+        use iceberg::puffin::{CompressionCodec, PuffinWriter};
+        use iceberg::spec::{DataContentType, DataFileBuilder, DataFileFormat, Struct};
+
+        let puffin_path = format!("{warehouse_location}/data/shared-deletes.puffin");
+        // Must go through the table's own `file_io`, not a freestanding
+        // `LocalFsStorageFactory`-backed one: `MemoryCatalog`'s `file_io` is a separate virtual
+        // store keyed by path string, not real disk, so a write through any other `FileIO`
+        // instance -- even to the same-looking absolute path -- is invisible to the later scan
+        // that reads this Puffin back through `table.file_io()`.
+        let output = table.file_io().new_output(&puffin_path).unwrap();
+
+        let mut writer = PuffinWriter::new(&output, StdHashMap::new(), false)
+            .await
+            .unwrap();
+
+        for (referenced_data_file, position) in deletes {
+            let mut delete_vector = iceberg::delete_vector::DeleteVector::default();
+            delete_vector.insert(*position);
+
+            let blob = delete_vector
+                .to_puffin_blob(StdHashMap::from([
+                    ("cardinality".to_owned(), "1".to_owned()),
+                    (
+                        "referenced-data-file".to_owned(),
+                        referenced_data_file.clone(),
+                    ),
+                ]))
+                .unwrap();
+
+            writer.add(blob, CompressionCodec::None).await.unwrap();
+        }
+
+        let result = writer.close_with_metadata().await.unwrap();
+        assert_eq!(
+            result.blobs_metadata.len(),
+            deletes.len(),
+            "every deletion vector must have landed in the one Puffin file"
+        );
+
+        result
+            .blobs_metadata
+            .iter()
+            .zip(deletes)
+            .map(|(blob, (referenced_data_file, _))| {
+                DataFileBuilder::default()
+                    .content(DataContentType::PositionDeletes)
+                    .file_path(puffin_path.clone())
+                    .file_format(DataFileFormat::Puffin)
+                    .partition(Struct::empty())
+                    .partition_spec_id(table.metadata().default_partition_spec_id())
+                    .record_count(1)
+                    .file_size_in_bytes(result.file_size_in_bytes)
+                    .referenced_data_file(Some(referenced_data_file.clone()))
+                    .content_offset(Some(blob.offset() as i64))
+                    .content_size_in_bytes(Some(blob.length() as i64))
+                    .build()
+                    .unwrap()
+            })
+            .collect()
+    }
+
+    /// Reads the table and returns the surviving `id` values, sorted.
+    async fn surviving_ids(table: &Table) -> Vec<i32> {
+        use futures::TryStreamExt;
+
+        let batches: Vec<RecordBatch> = table
+            .scan()
+            .build()
+            .unwrap()
+            .to_arrow()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+
+        let mut ids = Vec::new();
+        for batch in &batches {
+            let column = batch
+                .column_by_name("id")
+                .expect("the test schema has an id column");
+            let ids_array = column.as_any().downcast_ref::<Int32Array>().unwrap();
+            ids.extend(ids_array.iter().flatten());
+        }
+        ids.sort_unstable();
+        ids
+    }
+
+    /// End-to-end: a deletion vector must survive compaction of a *different* data file that shares
+    /// its Puffin.
+    ///
+    /// This is the shape that separates a correct implementation from a broken one, and it is easy to
+    /// get wrong in a test. Compacting *both* data files proves nothing: both deletion vectors become
+    /// dangling, and dropping both is correct, so such a test passes even against an implementation
+    /// that condemns deletion vectors by Puffin *path*. The discriminating case is one file rewritten
+    /// and the other left alone — then the untouched file's deletion vector must stay live even though
+    /// it sits in the same Puffin as one that is now dangling.
+    ///
+    /// A small file and a large file with a threshold between them is what forces that asymmetry, and
+    /// the test asserts the asymmetry actually held rather than trusting the planner.
+    #[tokio::test]
+    async fn test_v3_compaction_keeps_a_live_deletion_vector_sharing_a_puffin() {
+        let env = create_v3_test_env().await;
+        let batch = create_test_record_batch(&simple_table_schema());
+
+        // Small file: one batch of ids 1, 2, 3 — this one gets compacted.
+        let small_files = write_simple_files(&env.table, &env.warehouse_location, "small", 1).await;
+        assert_eq!(small_files.len(), 1);
+        let small_path = small_files[0].file_path().to_owned();
+
+        // Large file: ten batches — above the threshold, so compaction leaves it alone.
+        let mut large_writer =
+            build_simple_data_writer(&env.table, env.warehouse_location.clone(), "large").await;
+        for _ in 0..10 {
+            large_writer.write(batch.clone()).await.unwrap();
+        }
+        let large_files = large_writer.close().await.unwrap();
+        assert_eq!(large_files.len(), 1);
+        let large_path = large_files[0].file_path().to_owned();
+
+        let small_size = small_files[0].file_size_in_bytes();
+        let large_size = large_files[0].file_size_in_bytes();
+        assert!(
+            small_size < large_size,
+            "fixture must produce genuinely different sizes, got {small_size} and {large_size}"
+        );
+        let small_file_threshold = (small_size + large_size) / 2;
+
+        let mut all_files = small_files;
+        all_files.extend(large_files);
+        let table = append_and_commit(&env.table, env.catalog.as_ref(), all_files).await;
+
+        // One Puffin, two deletion vectors: position 0 of each data file.
+        let delete_files =
+            write_shared_puffin_deletion_vectors(&table, &env.warehouse_location, &[
+                (small_path.clone(), 0),
+                (large_path.clone(), 0),
+            ])
+            .await;
+        assert_eq!(
+            delete_files[0].file_path(),
+            delete_files[1].file_path(),
+            "precondition: both deletion vectors must live in the SAME Puffin, or this proves nothing"
+        );
+
+        let transaction = Transaction::new(&table);
+        let table = transaction
+            .rewrite_files()
+            .add_data_files(delete_files)
+            .apply(transaction)
+            .unwrap()
+            .commit(env.catalog.as_ref())
+            .await
+            .unwrap();
+
+        // 3 rows + 30 rows, less one deleted row from each file.
+        let before = surviving_ids(&table).await;
+        assert_eq!(before.len(), 31, "precondition: one row deleted per file");
+        assert_eq!(
+            before.iter().filter(|id| **id == 1).count(),
+            9,
+            "precondition: id=1 was deleted once from each file, leaving 9 of the 11 written"
+        );
+
+        let compaction = CompactionBuilder::new(env.catalog.clone(), env.table_ident.clone())
+            .with_config(Arc::new(
+                CompactionConfigBuilder::default()
+                    .planning(CompactionPlanningConfig::SmallFiles(
+                        SmallFilesConfigBuilder::default()
+                            .small_file_threshold_bytes(small_file_threshold)
+                            .build()
+                            .unwrap(),
+                    ))
+                    .build()
+                    .unwrap(),
+            ))
+            .build();
+
+        let result = compaction
+            .compact()
+            .await
+            .unwrap()
+            .expect("compaction must actually run, not decline");
+
+        // The whole point of the fixture: exactly one data file was rewritten, so the other file's
+        // deletion vector is still live while its neighbour in the same Puffin is now dangling.
+        assert_eq!(
+            result.stats.input_data_file_count, 1,
+            "exactly one *data* file must have been compacted, or the shared-Puffin asymmetry this \
+             test depends on never arose; stats {:?}",
+            result.stats
+        );
+        assert_eq!(
+            result.stats.input_position_delete_file_count, 1,
+            "the compacted file's deletion vector must have been consumed; stats {:?}",
+            result.stats
+        );
+
+        let compacted = env.catalog.load_table(&env.table_ident).await.unwrap();
+        let data_file_paths: Vec<String> = load_data_files_from_snapshot(&compacted, MAIN_BRANCH)
+            .await
+            .iter()
+            .map(|file| file.file_path().to_owned())
+            .collect();
+        assert!(
+            data_file_paths.contains(&large_path),
+            "the large file must have been left in place, got {data_file_paths:?}"
+        );
+
+        let after = surviving_ids(&compacted).await;
+        assert_eq!(
+            after.len(),
+            31,
+            "compacting the small file must not resurrect the row deleted from the large file by a \
+             deletion vector sharing the same Puffin"
+        );
+        assert_eq!(
+            after.iter().filter(|id| **id == 1).count(),
+            9,
+            "the large file's deleted id=1 must still be deleted"
+        );
+    }
+
     #[tokio::test]
     async fn test_write_commit_and_compaction() {
         let env = create_test_env().await;

--- a/core/src/executor/datafusion/datafusion_processor.rs
+++ b/core/src/executor/datafusion/datafusion_processor.rs
@@ -2215,7 +2215,6 @@ mod tests {
                 predicate: None,
                 deletes: vec![],
                 sequence_number: 0,
-                file_sequence_number: Some(0),
                 file_size_in_bytes: 1024,
                 partition,
                 partition_spec,

--- a/core/src/executor/datafusion/iceberg_file_task_scan.rs
+++ b/core/src/executor/datafusion/iceberg_file_task_scan.rs
@@ -736,7 +736,6 @@ mod tests {
             predicate: None,
             deletes: vec![],
             sequence_number: 0,
-            file_sequence_number: Some(0),
             file_size_in_bytes: length,
             partition: None,
             partition_spec: None,

--- a/core/src/file_selection/mod.rs
+++ b/core/src/file_selection/mod.rs
@@ -34,7 +34,7 @@ impl FileSelector {
     pub(crate) fn validate_file_sequence_numbers(data_files: &[FileScanTask]) -> Result<()> {
         if let Some(task) = data_files
             .iter()
-            .find(|task| task.file_sequence_number.is_none())
+            .find(|task| task.data_sequence_number.is_none())
         {
             return Err(crate::CompactionError::Config(format!(
                 "bounded compaction requires file_sequence_number for every scanned data file; missing for {}",

--- a/core/src/file_selection/strategy.rs
+++ b/core/src/file_selection/strategy.rs
@@ -736,7 +736,7 @@ impl FileSequenceNumberFilterStrategy {
 impl FileFilterStrategy for FileSequenceNumberFilterStrategy {
     fn matches(&self, data_file: &FileScanTask) -> bool {
         data_file
-            .file_sequence_number
+            .data_sequence_number
             .is_some_and(|sequence_number| sequence_number <= self.max_file_sequence_number)
     }
 }
@@ -1324,7 +1324,6 @@ mod tests {
                 predicate: None,
                 deletes,
                 sequence_number: 1,
-                file_sequence_number: Some(1),
                 file_size_in_bytes: self.size,
                 partition: self.partition,
                 partition_spec: None,
@@ -1661,9 +1660,9 @@ mod tests {
     #[test]
     fn test_sequence_bound_filters_all_planning_strategies() {
         let mut old_file = TestFileBuilder::new("old.parquet").with_deletes().build();
-        old_file.file_sequence_number = Some(3);
+        old_file.data_sequence_number = Some(3);
         let mut new_file = TestFileBuilder::new("new.parquet").with_deletes().build();
-        new_file.file_sequence_number = Some(4);
+        new_file.data_sequence_number = Some(4);
 
         let configs = [
             CompactionPlanningConfig::SmallFiles(
@@ -1708,7 +1707,7 @@ mod tests {
     #[test]
     fn test_bounded_planning_rejects_missing_file_sequence_number() {
         let mut missing = TestFileBuilder::new("missing.parquet").build();
-        missing.file_sequence_number = None;
+        missing.data_sequence_number = None;
         let config = CompactionPlanningConfig::Full(
             FullCompactionConfigBuilder::default()
                 .max_file_sequence_number(3_i64)


### PR DESCRIPTION
> **Draft**, because it depends on an unmerged upstream PR — see *Dependency* below. The code is complete and CI should be
> green; the only thing standing between this and ready-for-review is the temporary dep pin in the second commit.

## The bug

Compaction reads a snapshot, applies the deletes visible at that snapshot by materializing them into new data files, then
replaces the originals.

If another writer commits deletes for one of the data files being replaced in between, those deletes are **not** in the new
files — and because removing the old data file also retires the new delete file as *dangling*, the rows it deleted
**silently come back**.

Nothing currently detects this. `set_check_file_existence(true)` only verifies that the files being removed still exist,
and they do.

This is what the existing TODO in `core/src/compaction/mod.rs` asks for:

```rust
// TODO: support validation of data files and delete files with starting snapshot before applying the rewrite
```

## The change

Pass `starting_snapshot_id` — already in scope, already used for the sequence number — to the rewrite action, on **both**
commit paths (`use_starting_sequence_number` and the fallback). The commit then fails instead of silently dropping the
concurrent deletes.

## Note: the commit retry cannot recover from this, by design

Worth being explicit, because it looks like a retry bug otherwise. The retry closure clones the already-computed
`data_files`/`delete_files` and only reloads the table, so it re-commits **identical output** against a table that still
has the concurrent delete. The conflict is permanent: retries exhaust with backoff, then fail.

That is the intended outcome — the compaction has to be *planned again* from the newer snapshot, which the caller does on
its next run. It does mean tables under concurrent write load will start reporting compaction *failures* where they
previously reported (silently incorrect) success, so it is worth knowing before rollout.

A follow-up worth considering upstream: give this conflict a distinct `ErrorKind` so compaction can fail fast rather than
burning `max_retries` on an unwinnable retry. Right now it surfaces as `DataInvalid`, which the retry predicate matches.

## Dependency

Needs `ReplaceFilesAction::validate_from_snapshot_id` from **risingwavelabs/iceberg-rust#202** (open, CI green).

The second commit temporarily pins the `iceberg*` deps to that PR's head (`b087b307`) so this builds and tests now — Cargo
resolves it because GitHub keeps a PR head reachable in the upstream repo. **That commit is not for merge**: re-pin to the
merge commit on `dev_rebase_main_20260303` once #202 lands, and I'll mark this ready.

All five `iceberg*` deps move together on purpose — pinning only `iceberg` would pull in two incompatible copies of the
crate.

## Verification

With the pin in place: `cargo fmt --all -- --check` clean, `cargo clippy -p iceberg-compaction-core --all-targets` clean,
and `cargo test -p iceberg-compaction-core --lib` **134 passed / 0 failed** — including
`test_write_commit_and_compaction` and `test_small_files_compaction_with_validation`, which exercise the commit path this
touches.

I have not added a test that reproduces the concurrent-delete race here; the validation logic itself is unit-tested
upstream in #202 (four cases, including that a delete for an *untouched* data file must **not** conflict, so compaction is
not over-rejected). Happy to add an integration-level race test here if you'd like one.
