### PR TITLE
chore: add silver-ymz as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Code owners for iceberg-compaction.
 # Automatically request reviews from these users on all PRs.
 # See https://docs.github.com/articles/about-code-owners
-* @mwylde @nagraham @Li0k @chenzl25 @vovacf201 @netgusto @agaddis02
+* @mwylde @nagraham @Li0k @chenzl25 @vovacf201 @netgusto @agaddis02 @silver-ymz


### PR DESCRIPTION
## Summary

- add `@silver-ymz` to the repository-wide CODEOWNERS rule
- keep all existing code owners unchanged

## Validation

- confirmed the GitHub user exists and has admin access to the repository
- `git diff --check`