### PR TITLE
chore: bump iceberg-rust to 20260807 baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7dc1d44994b16fa6893f7983da84dd3dc55e8e9a#7dc1d44994b16fa6893f7983da84dd3dc55e8e9a"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c39309944d2b7f1c81ae2d24c3aa32fd1da66590#c39309944d2b7f1c81ae2d24c3aa32fd1da66590"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7dc1d44994b16fa6893f7983da84dd3dc55e8e9a#7dc1d44994b16fa6893f7983da84dd3dc55e8e9a"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c39309944d2b7f1c81ae2d24c3aa32fd1da66590#c39309944d2b7f1c81ae2d24c3aa32fd1da66590"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7dc1d44994b16fa6893f7983da84dd3dc55e8e9a#7dc1d44994b16fa6893f7983da84dd3dc55e8e9a"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c39309944d2b7f1c81ae2d24c3aa32fd1da66590#c39309944d2b7f1c81ae2d24c3aa32fd1da66590"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7dc1d44994b16fa6893f7983da84dd3dc55e8e9a#7dc1d44994b16fa6893f7983da84dd3dc55e8e9a"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c39309944d2b7f1c81ae2d24c3aa32fd1da66590#c39309944d2b7f1c81ae2d24c3aa32fd1da66590"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7dc1d44994b16fa6893f7983da84dd3dc55e8e9a#7dc1d44994b16fa6893f7983da84dd3dc55e8e9a"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c39309944d2b7f1c81ae2d24c3aa32fd1da66590#c39309944d2b7f1c81ae2d24c3aa32fd1da66590"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=32323566972e9f574ab9a90ba411a63b35dad86a#32323566972e9f574ab9a90ba411a63b35dad86a"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7dc1d44994b16fa6893f7983da84dd3dc55e8e9a#7dc1d44994b16fa6893f7983da84dd3dc55e8e9a"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=32323566972e9f574ab9a90ba411a63b35dad86a#32323566972e9f574ab9a90ba411a63b35dad86a"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7dc1d44994b16fa6893f7983da84dd3dc55e8e9a#7dc1d44994b16fa6893f7983da84dd3dc55e8e9a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=32323566972e9f574ab9a90ba411a63b35dad86a#32323566972e9f574ab9a90ba411a63b35dad86a"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7dc1d44994b16fa6893f7983da84dd3dc55e8e9a#7dc1d44994b16fa6893f7983da84dd3dc55e8e9a"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=32323566972e9f574ab9a90ba411a63b35dad86a#32323566972e9f574ab9a90ba411a63b35dad86a"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7dc1d44994b16fa6893f7983da84dd3dc55e8e9a#7dc1d44994b16fa6893f7983da84dd3dc55e8e9a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=32323566972e9f574ab9a90ba411a63b35dad86a#32323566972e9f574ab9a90ba411a63b35dad86a"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7dc1d44994b16fa6893f7983da84dd3dc55e8e9a#7dc1d44994b16fa6893f7983da84dd3dc55e8e9a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,7 +26,21 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -86,16 +110,18 @@ checksum = "36fa98bc79671c7981272d91a8753a928ff6a1cd8e4f20a44c45bd5d313840bf"
 dependencies = [
  "bigdecimal",
  "bon",
- "digest",
+ "crc32fast",
+ "digest 0.10.7",
  "log",
  "miniz_oxide",
  "num-bigint",
  "quad-rand",
- "rand 0.9.2",
+ "rand",
  "regex-lite",
  "serde",
  "serde_bytes",
  "serde_json",
+ "snap",
  "strum",
  "strum_macros",
  "thiserror",
@@ -132,9 +158,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d441fdda254b65f3e9025910eb2c2066b6295d9c8ed409522b8d2ace1ff8574c"
+checksum = "6cfdd0833e32a9874d2b55089333ad310c0be208aafa277385ce2461dec90be3"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -153,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -167,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -178,7 +204,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -186,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
 dependencies = [
  "bytes",
  "half",
@@ -198,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0127816c96533d20fc938729f48c52d3e48f99717e7a0b5ade77d742510736d"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -209,7 +235,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "comfy-table",
  "half",
@@ -220,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca025bd0f38eeecb57c2153c0123b960494138e6a957bbda10da2b25415209fe"
+checksum = "af0dd6d90d1955e9f9a014c1e563ee8aeffc21909085d25623e1da44d96eca26"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -235,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -248,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
+checksum = "29a908a11fcfb3fb2f6730f4ac15e367bc644e419155e96238f68cf3adde572b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -264,18 +290,19 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ead0914e4861a531be48fe05858265cf854a4880b9ed12618b1d08cba9bebc8"
+checksum = "b8a96aed3931c076adee39ec2a40d8219fc7f09e79bcdaca1df16272993e1e14"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-data",
+ "arrow-ord",
  "arrow-schema",
+ "arrow-select",
  "chrono",
  "half",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "lexical-core",
  "memchr",
@@ -288,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -301,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
+checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -314,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
 dependencies = [
  "serde_core",
  "serde_json",
@@ -324,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -338,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -634,11 +661,11 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2",
+ "sha2 0.10.9",
  "time",
  "tracing",
 ]
@@ -684,23 +711,17 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.27",
- "h2 0.4.13",
- "http 0.2.12",
+ "h2",
  "http 1.4.0",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper 1.8.1",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tracing",
 ]
@@ -842,6 +863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,12 +877,6 @@ dependencies = [
  "outref",
  "vsimd",
 ]
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bigdecimal"
@@ -879,6 +900,12 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -889,7 +916,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -903,7 +930,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -916,12 +943,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
+name = "block-buffer"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1024,15 +1051,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,7 +1104,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1097,6 +1115,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1141,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -1197,12 +1231,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32c"
-version = "0.6.8"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
- "rustc_version",
+ "libc",
+]
+
+[[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin",
 ]
 
 [[package]]
@@ -1251,7 +1295,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1283,6 +1337,34 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ctor"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9bb72bb94fdc1bd619f4c18cc91ecf6302aeb333d31b3c6ec0bb841cd920209"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1405,14 +1487,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9f8117889ba9503440f1dd79ebab32ba52ccf1720bb83cd718a29d4edc0d16"
+checksum = "754ef4e8f073922a26f5b23133b9db4829342362b09be0bc94309cf261c2f098"
 dependencies = [
  "arrow",
  "arrow-schema",
  "async-trait",
- "bytes",
  "bzip2",
  "chrono",
  "datafusion-catalog",
@@ -1442,14 +1523,13 @@ dependencies = [
  "datafusion-sql",
  "flate2",
  "futures",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "liblzma",
  "log",
  "object_store",
  "parking_lot",
  "parquet",
- "rand 0.9.2",
- "regex",
  "sqlparser",
  "tempfile",
  "tokio",
@@ -1460,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be893b73a13671f310ffcc8da2c546b81efcc54c22e0382c0a28aa3537017137"
+checksum = "06afd1e38dd27bbb1258685a1fc6524df6aff4e07b25b393a47de59635178d99"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1485,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830487b51ed83807d6b32d6325f349c3144ae0c9bf772cf2a712db180c31d5e6"
+checksum = "f0668fb32c12065ec242be0e5b4bc62bd7a06a0be3ecd83791ef877e4be67e02"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1508,34 +1588,35 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d7663f3af955292f8004e74bcaf8f7ea3d66cc38438749615bb84815b61a293"
+checksum = "ca43b263cdff57042cfa8fb817fb3469f4878933380dccff25f5e793580abbf9"
 dependencies = [
- "ahash",
  "arrow",
  "arrow-ipc",
+ "arrow-schema",
  "chrono",
+ "foldhash 0.2.0",
  "half",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "libc",
  "log",
  "object_store",
  "parquet",
- "paste",
  "recursive",
  "sqlparser",
  "tokio",
+ "uuid",
  "web-time",
 ]
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f590205c7e32fe1fea48dd53ffb406e56ae0e7a062213a3ac848db8771641bd"
+checksum = "05f0ba2b864792bdca4d76c59a1de0ab6e1b61946596b9936888dbd6360035f2"
 dependencies = [
  "futures",
  "log",
@@ -1544,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde1e030a9dc87b743c806fbd631f5ecfa2ccaa4ffb61fa19144a07fea406b79"
+checksum = "b840a8bce0bcbf5afad02946d438591e7c373f7afccaf3d874c04485772514dd"
 dependencies = [
  "arrow",
  "async-compression",
@@ -1570,7 +1651,8 @@ dependencies = [
  "liblzma",
  "log",
  "object_store",
- "rand 0.9.2",
+ "parking_lot",
+ "rand",
  "tokio",
  "tokio-util",
  "url",
@@ -1579,9 +1661,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331ebae7055dc108f9b54994b93dff91f3a17445539efe5b74e89264f7b36e15"
+checksum = "a24cc0b9cf6e367f27f27406eff13abf48a11b72446aaa40b3105c0ded5c17d9"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1603,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0d475088325e2986876aa27bb30d0574f72a22955a527d202f454681d55c5c"
+checksum = "e1abe56b2a7a2d1d6de5117dd1a203181e267f28529faa5da546947621b697d7"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1626,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1520d81f31770f3ad6ee98b391e75e87a68a5bb90de70064ace5e0a7182fe8"
+checksum = "9c3e467f0611ad7bdd5aad17c63c9bb6182d04e5282e5496d897ea2b49c024ba"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1643,16 +1725,15 @@ dependencies = [
  "datafusion-session",
  "futures",
  "object_store",
- "serde_json",
  "tokio",
  "tokio-stream",
 ]
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95be805d0742ab129720f4c51ad9242cd872599cdb076098b03f061fcdc7f946"
+checksum = "4cc35b92cd560082155e80d9c826929c852d3c51543f4affd3a51c464a0aab3a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1662,6 +1743,7 @@ dependencies = [
  "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-functions",
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-adapter",
@@ -1680,20 +1762,19 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c93ad9e37730d2c7196e68616f3f2dd3b04c892e03acd3a8eeca6e177f3c06a"
+checksum = "d69bb69d8769e34f76839c960dbde24c1ac0c885a79b6c3c2287bdc56ec67891"
 
 [[package]]
 name = "datafusion-execution"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9437d3cd5d363f9319f8122182d4d233427de79c7eb748f23054c9aaa0fdd8df"
+checksum = "d8eac0a09bc8d263f52025cad9e001da4d8138d633fa288edda4d06b1772eae6"
 dependencies = [
  "arrow",
  "arrow-buffer",
  "async-trait",
- "chrono",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
@@ -1702,18 +1783,19 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand 0.9.2",
+ "rand",
  "tempfile",
  "url",
 ]
 
 [[package]]
 name = "datafusion-expr"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67164333342b86521d6d93fa54081ee39839894fb10f7a700c099af96d7552cf"
+checksum = "eeb14d374767ee0fc62dc79a5ba8bcf8a63c14e993c7d992d0e63adfa23d77d3"
 dependencies = [
  "arrow",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -1722,9 +1804,8 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
- "paste",
  "recursive",
  "serde_json",
  "sqlparser",
@@ -1732,26 +1813,25 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab05fdd00e05d5a6ee362882546d29d6d3df43a6c55355164a7fbee12d163bc9"
+checksum = "b7b19a8c95522bee8cbb313d74263b85e355d2b52f42e67ef5694bf5de9e9356"
 dependencies = [
  "arrow",
  "datafusion-common",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04fb863482d987cf938db2079e07ab0d3bb64595f28907a6c2f8671ad71cca7e"
+checksum = "5f64c983bbbdcb729d921a2b2ac3375598719b5cc0c30345ad664936f3176fc7"
 dependencies = [
  "arrow",
  "arrow-buffer",
- "base64",
+ "base64 0.22.1",
  "blake2",
  "blake3",
  "chrono",
@@ -1762,26 +1842,25 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-macros",
+ "datafusion-physical-expr-common",
  "hex",
  "itertools 0.14.0",
  "log",
  "md-5",
  "memchr",
  "num-traits",
- "rand 0.9.2",
+ "rand",
  "regex",
- "sha2",
- "unicode-segmentation",
+ "sha2 0.11.0",
  "uuid",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829856f4e14275fb376c104f27cbf3c3b57a9cfe24885d98677525f5e43ce8d6"
+checksum = "89bc17041e424a47ed062f43df24d84aab8b57c4c3221e5c1a5eef46d6c5718b"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-doc",
@@ -1791,19 +1870,18 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
+ "foldhash 0.2.0",
  "half",
  "log",
  "num-traits",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08af79cc3d2aa874a362fb97decfcbd73d687190cb096f16a6c85a7780cce311"
+checksum = "97dd2a9e865c6108059f5b37b77934f84b50bfb108f837bd0e5c9536e03f0545"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -1812,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465ae3368146d49c2eda3e2c0ef114424c87e8a6b509ab34c1026ace6497e790"
+checksum = "75f0bdfeef16d96417b9632ef855645376b242e9006a126dfd0bedfc54a93f5f"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1828,34 +1906,34 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-macros",
  "datafusion-physical-expr-common",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itertools 0.14.0",
  "itoa",
  "log",
- "paste",
+ "memchr",
 ]
 
 [[package]]
 name = "datafusion-functions-table"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6156e6b22fcf1784112fc0173f3ae6e78c8fdb4d3ed0eace9543873b437e2af6"
+checksum = "f4e4941673c917819616877e9993da4503e4f4739812be0bc32c5356184c6383"
 dependencies = [
  "arrow",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-physical-expr",
  "datafusion-physical-plan",
  "parking_lot",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca7baec14f866729012efb89011a6973f3a346dc8090c567bfcd328deff551c1"
+checksum = "12dd2e16c12b84b6f6b41b19f55b366dd1c46876bb35b86896c6349067379e8d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1866,14 +1944,13 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "log",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159228c3280d342658466bb556dc24de30047fe1d7e559dc5d16ccc5324166f9"
+checksum = "4cdc5e4b6f8b6ef823cc1c761f85088ad4c884fe8df64df3cbcc6b2b84698441"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1881,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5427e5da5edca4d21ea1c7f50e1c9421775fe33d7d5726e5641a833566e7578"
+checksum = "1a3614234dd93578c92428cb4f408e020874f0d2b7e6c90c928d9d28b5df2ceb"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -1892,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89099eefcd5b223ec685c36a41d35c69239236310d71d339f2af0fa4383f3f46"
+checksum = "a0635620b050b81bb92764e99250868f654e2cd5ad1bece413283b3f73c83179"
 dependencies = [
  "arrow",
  "chrono",
@@ -1902,7 +1979,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-physical-expr",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
  "recursive",
@@ -1912,11 +1989,10 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f222df5195d605d79098ef37bdd5323bff0131c9d877a24da6ec98dfca9fe36"
+checksum = "8cabf7a86eb70b816729e33c81bf7767c936ee1226f607a114f5dac2decac8d0"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -1924,11 +2000,10 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "parking_lot",
- "paste",
  "petgraph",
  "recursive",
  "tokio",
@@ -1936,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40838625d63d9c12549d81979db3dd675d159055eb9135009ba272ab0e8d0f64"
+checksum = "de222e04f7e6744501555a54ab0abe26bfdfebee380af79a9bdc175704246859"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1951,26 +2026,26 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eacbcc4cfd502558184ed58fa3c72e775ec65bf077eef5fd2b3453db676f893c"
+checksum = "72d0d0057fc5a502d45c870cb6d47c66eb7bdd5edb1bd71ad6f3f724975ac2a8"
 dependencies = [
- "ahash",
  "arrow",
  "chrono",
  "datafusion-common",
  "datafusion-expr-common",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "parking_lot",
+ "pin-project",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d501d0e1d0910f015677121601ac177ec59272ef5c9324d1147b394988f40941"
+checksum = "86046eed10950c5f9aaed9acfd148e9bd2e1dfdfe4f9aef607d1447b271e4183"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1987,12 +2062,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463c88ad6f1ecab1810f4c9f046898bee035b370137eb79b2b2db925e270631d"
+checksum = "9bc84da934c903407ba297971ebcc020c4c1a38aafd765d6c144c76eff3fa6a1"
 dependencies = [
- "ahash",
  "arrow",
+ "arrow-data",
+ "arrow-ipc",
  "arrow-ord",
  "arrow-schema",
  "async-trait",
@@ -2007,8 +2083,8 @@ dependencies = [
  "datafusion-physical-expr-common",
  "futures",
  "half",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
  "num-traits",
@@ -2019,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2857618a0ecbd8cd0cf29826889edd3a25774ec26b2995fc3862095c95d88fc6"
+checksum = "eb63eeac6de19be40f487b65dd84e546195f783c5a9928618e0c4f2a3569b0d7"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2030,15 +2106,14 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "itertools 0.14.0",
  "log",
 ]
 
 [[package]]
 name = "datafusion-session"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8637e35022c5c775003b3ab1debc6b4a8f0eb41b069bdd5475dd3aa93f6eba"
+checksum = "5f961d209177f91bd014db5cbb2c33b7d28a2597b9003e77f17aeb712964315a"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2050,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "53.0.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d9e9f16a1692a11c94bcc418191fa15fd2b4d72a0c1a0c607db93c0b84dd81"
+checksum = "b1d71cb454da682b2af7488e1fc1ddd72ee1b28f19297b8ccad73f0a21ee9a69"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2060,7 +2135,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-functions-nested",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "recursive",
  "regex",
@@ -2068,14 +2143,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.10"
+name = "defmt"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -2125,10 +2220,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2199,7 +2305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2269,7 +2375,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "rustc_version",
 ]
 
@@ -2412,13 +2518,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2b3d0b409a042a380111af38136310839af8ac1a0917fb6e84515ed1e4bf3ee"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "ring",
  "rustls-pki-types",
@@ -2482,6 +2588,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2501,25 +2617,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -2530,7 +2627,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2572,20 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2610,16 +2696,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
+name = "hmac"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "windows-sys 0.61.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2684,39 +2770,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
-name = "hyper"
-version = "0.14.32"
+name = "hybrid-array"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
+ "typenum",
 ]
 
 [[package]]
@@ -2729,7 +2794,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -2743,35 +2808,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2780,18 +2829,18 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2823,9 +2872,10 @@ dependencies = [
 
 [[package]]
 name = "iceberg"
-version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+version = "0.10.0"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=4cbd183953f89d7179b64072940a98232b958307#4cbd183953f89d7179b64072940a98232b958307"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "apache-avro",
  "array-init",
@@ -2841,7 +2891,7 @@ dependencies = [
  "as-any",
  "async-trait",
  "backon",
- "base64",
+ "base64 0.22.1",
  "bimap",
  "bytes",
  "chrono",
@@ -2851,18 +2901,16 @@ dependencies = [
  "fastnum",
  "flate2",
  "fnv",
+ "form_urlencoded",
  "futures",
- "hashbrown 0.17.0",
  "itertools 0.13.0",
  "moka",
  "murmur3",
  "once_cell",
- "opendal",
  "ordered-float 4.6.0",
  "parquet",
- "rand 0.8.5",
- "reqsign",
- "reqwest",
+ "rand",
+ "reqwest 0.12.28",
  "roaring",
  "serde",
  "serde_bytes",
@@ -2877,42 +2925,42 @@ dependencies = [
  "typetag",
  "url",
  "uuid",
+ "zeroize",
  "zstd",
 ]
 
 [[package]]
 name = "iceberg-catalog-glue"
-version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+version = "0.10.0"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=4cbd183953f89d7179b64072940a98232b958307#4cbd183953f89d7179b64072940a98232b958307"
 dependencies = [
  "anyhow",
  "async-trait",
  "aws-config",
  "aws-sdk-glue",
  "iceberg",
+ "iceberg-storage-opendal",
  "serde_json",
  "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "iceberg-catalog-rest"
-version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+version = "0.10.0"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=4cbd183953f89d7179b64072940a98232b958307#4cbd183953f89d7179b64072940a98232b958307"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "gcp_auth",
  "http 1.4.0",
  "iceberg",
  "itertools 0.13.0",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_derive",
  "serde_json",
  "tokio",
- "tracing",
  "typed-builder",
  "uuid",
 ]
@@ -2924,7 +2972,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "backon",
- "ctor",
+ "ctor 0.2.9",
  "datafusion",
  "derive_builder",
  "futures",
@@ -2936,7 +2984,7 @@ dependencies = [
  "mixtrics",
  "parquet",
  "port_scanner",
- "rand 0.9.2",
+ "rand",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2962,7 +3010,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
- "ctor",
+ "ctor 0.2.9",
  "datafusion",
  "futures",
  "iceberg",
@@ -2971,7 +3019,7 @@ dependencies = [
  "iceberg-datafusion",
  "parquet",
  "port_scanner",
- "rand 0.9.2",
+ "rand",
  "serde",
  "serde_yaml",
  "tempfile",
@@ -2983,8 +3031,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg-datafusion"
-version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+version = "0.10.0"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=4cbd183953f89d7179b64072940a98232b958307#4cbd183953f89d7179b64072940a98232b958307"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2995,6 +3043,25 @@ dependencies = [
  "parquet",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "iceberg-storage-opendal"
+version = "0.10.0"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=4cbd183953f89d7179b64072940a98232b958307#4cbd183953f89d7179b64072940a98232b958307"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "futures",
+ "iceberg",
+ "opendal",
+ "reqsign-aws-v4",
+ "reqsign-core",
+ "serde",
+ "typetag",
+ "url",
 ]
 
 [[package]]
@@ -3124,12 +3191,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3140,7 +3207,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -3201,25 +3267,39 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.22"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819b44bc7c87d9117eb522f14d46e918add69ff12713c475946b0a29363ed1c2"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
+ "js-sys",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.22"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470252db18ecc35fd766c0891b1e3ec6cbbcd62507e85276c01bf75d8e94d4a1"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
  "syn",
@@ -3238,6 +3318,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3261,28 +3390,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "9.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
-dependencies = [
- "base64",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -3355,9 +3466,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "liblzma"
@@ -3386,6 +3497,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "link-section"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc98458dfe90986c5e2f6ddcf68360c7e5c4252600153e06aa4ee8176c0f8d1"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3408,9 +3531,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -3438,12 +3561,21 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "mea"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2640d335e7273dacdcf51044026139b2e269c3bb0dfc3f8cb3496b85e3f6a42c"
+dependencies = [
+ "slab",
 ]
 
 [[package]]
@@ -3464,9 +3596,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -3515,7 +3647,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3527,22 +3659,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
 ]
 
 [[package]]
@@ -3566,17 +3682,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -3632,33 +3737,144 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "opendal"
-version = "0.55.0"
+name = "opaque-debug"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d075ab8a203a6ab4bc1bce0a4b9fe486a72bf8b939037f4b78d95386384bc80a"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "opendal"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f20562cc7447fcc915fc5c23df305a412ea80a733c9f2fd9e2d267e2815be6d"
+dependencies = [
+ "ctor 1.0.11",
+ "opendal-core",
+ "opendal-http-transport-reqwest",
+ "opendal-layer-concurrent-limit",
+ "opendal-layer-logging",
+ "opendal-layer-retry",
+ "opendal-layer-timeout",
+ "opendal-service-fs",
+ "opendal-service-s3",
+]
+
+[[package]]
+name = "opendal-core"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec75551ff4cf3e57da98979f6a937aaa9ddb3915bf68cc17d03df733be6646ed"
 dependencies = [
  "anyhow",
- "backon",
- "base64",
+ "base64 0.23.1",
  "bytes",
- "crc32c",
  "futures",
- "getrandom 0.2.17",
  "http 1.4.0",
- "http-body 1.0.1",
  "jiff",
  "log",
  "md-5",
+ "mea",
  "percent-encoding",
- "quick-xml 0.38.4",
- "reqsign",
- "reqwest",
+ "quick-xml",
+ "reqsign-core",
  "serde",
  "serde_json",
- "sha2",
  "tokio",
  "url",
  "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "opendal-http-transport-reqwest"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad4d4f19c3ce01126a30611f8e544eaa217104a278c889ac17c9374fe4f9e4ef"
+dependencies = [
+ "bytes",
+ "futures",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "opendal-core",
+ "reqwest 0.13.4",
+]
+
+[[package]]
+name = "opendal-layer-concurrent-limit"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249ac5b0aa5a7a6c3737342d10456067937f9c9a6f3f02544271f7908ab91081"
+dependencies = [
+ "futures",
+ "http 1.4.0",
+ "mea",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-logging"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c75411ab00f77851ff086b686c1e9ca8175ac18c15afa2cb75b9036436cb06c"
+dependencies = [
+ "log",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-retry"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80b7738bd5f233ad8da39af9b9316b9b7a4eaddd91e8e32a1e19b7030688121d"
+dependencies = [
+ "backon",
+ "log",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-timeout"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a704141924500f3803c05ed871b53305d2a2f11cb5ef20160c3ee688a1857f66"
+dependencies = [
+ "opendal-core",
+ "tokio",
+]
+
+[[package]]
+name = "opendal-service-fs"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826c4e17a30643b888fe983897f9a4b23b07066e1d069727a923cc8fb419a702"
+dependencies = [
+ "bytes",
+ "log",
+ "opendal-core",
+ "serde",
+ "tokio",
+ "xattr",
+]
+
+[[package]]
+name = "opendal-service-s3"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e80cdf192d7eff05feed747894d64f81905ac4eaf132edf7ea270abdd2d663"
+dependencies = [
+ "base64 0.23.1",
+ "bytes",
+ "crc-fast",
+ "http 1.4.0",
+ "log",
+ "md-5",
+ "opendal-core",
+ "quick-xml",
+ "reqsign-aws-v4",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "serde",
+ "url",
 ]
 
 [[package]]
@@ -3732,9 +3948,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+checksum = "d298093b2dec60289dce0684c986d0f7679e9dd15771c2c65406e1aaf604a704"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -3743,14 +3959,14 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64",
+ "base64 0.22.1",
  "brotli",
  "bytes",
  "chrono",
  "flate2",
  "futures",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "lz4_flex",
  "num-bigint",
  "num-integer",
@@ -3760,6 +3976,7 @@ dependencies = [
  "parquet-variant-compute",
  "parquet-variant-json",
  "paste",
+ "ring",
  "seq-macro",
  "simdutf8",
  "snap",
@@ -3771,29 +3988,31 @@ dependencies = [
 
 [[package]]
 name = "parquet-variant"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf493f3c9ddd984d0efb019f67343e4aa4bab893931f6a14b82083065dc3d28"
+checksum = "3fc70e87931167a4a3fde2ee923023a0624367691e3fd503476a1084dda5a054"
 dependencies = [
+ "arrow",
  "arrow-schema",
  "chrono",
  "half",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
+ "num-traits",
  "simdutf8",
  "uuid",
 ]
 
 [[package]]
 name = "parquet-variant-compute"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac038d46a503a7d563b4f5df5802c4315d5343d009feab195d15ac512b4cb27"
+checksum = "823a9ecee8fd83a68f7165ef13acc840c4d7ed995838ba99d4714b20a2b5e780"
 dependencies = [
  "arrow",
  "arrow-schema",
  "chrono",
  "half",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "parquet-variant",
  "parquet-variant-json",
  "serde_json",
@@ -3802,12 +4021,12 @@ dependencies = [
 
 [[package]]
 name = "parquet-variant-json"
-version = "58.1.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "015a09c2ffe5108766c7c1235c307b8a3c2ea64eca38455ba1a7f3a7f32f16e2"
+checksum = "6f37a91177e2dddb10333546952fcf2b7674b97ebd9449432f24b883d6ea8108"
 dependencies = [
  "arrow-schema",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "parquet-variant",
  "serde_json",
@@ -3819,35 +4038,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
-]
-
-[[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64",
- "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -3863,7 +4053,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -3918,48 +4108,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs5"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
-dependencies = [
- "aes",
- "cbc",
- "der",
- "pbkdf2",
- "scrypt",
- "sha2",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "pkcs5",
- "rand_core 0.6.4",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "port_scanner"
@@ -4043,19 +4207,9 @@ checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -4073,8 +4227,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
- "socket2 0.6.2",
+ "rustls",
+ "socket2 0.5.10",
  "thiserror",
  "tokio",
  "tracing",
@@ -4087,13 +4241,14 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror",
@@ -4111,7 +4266,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4133,33 +4288,12 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4216,7 +4350,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4275,33 +4409,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "reqsign"
-version = "0.16.5"
+name = "reqsign-aws-v4"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43451dbf3590a7590684c25fb8d12ecdcc90ed3ac123433e500447c7d77ed701"
+checksum = "cc883bc56889f3e4a419265c87facea222a921debc5c6f15c7fd8b68ec4b36b2"
 dependencies = [
  "anyhow",
- "async-trait",
- "base64",
- "chrono",
+ "bytes",
  "form_urlencoded",
- "getrandom 0.2.17",
  "hex",
- "hmac",
- "home",
  "http 1.4.0",
- "jsonwebtoken",
  "log",
  "percent-encoding",
- "quick-xml 0.37.5",
- "rand 0.8.5",
- "reqwest",
- "rsa",
+ "quick-xml",
+ "reqsign-core",
  "rust-ini",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sha1",
- "sha2",
+]
+
+[[package]]
+name = "reqsign-core"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e38b44697c60a823705ccef85cb04d8e0527c9d16ed7c58bf1c6395bdd24ceb"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "hex",
+ "hmac 0.13.0",
+ "http 1.4.0",
+ "jiff",
+ "log",
+ "percent-encoding",
+ "sha1",
+ "sha2 0.11.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "reqsign-file-read-tokio"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688ff0ae421b8d4b92b53fdafaf53df2de28f428a9962edcf21702990b26f74b"
+dependencies = [
+ "anyhow",
+ "reqsign-core",
  "tokio",
 ]
 
@@ -4311,29 +4468,59 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
+ "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4343,7 +4530,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -4379,27 +4565,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "sha2",
- "signature",
- "spki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4430,23 +4595,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4459,7 +4612,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -4487,14 +4640,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-platform-verifier"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "ring",
- "untrusted",
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4519,15 +4689,6 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
 
 [[package]]
 name = "same-file"
@@ -4578,33 +4739,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "pbkdf2",
- "salsa20",
- "sha2",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4724,11 +4864,11 @@ version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -4755,7 +4895,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -4764,13 +4904,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4780,8 +4920,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4810,38 +4961,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror",
- "time",
-]
 
 [[package]]
 name = "siphasher"
@@ -4879,9 +5018,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -4889,25 +5028,15 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "sqlparser"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
 dependencies = [
  "log",
  "recursive",
@@ -5024,7 +5153,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5134,25 +5263,25 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5161,21 +5290,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 
@@ -5225,7 +5344,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -5360,9 +5479,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"
@@ -5413,6 +5532,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5450,9 +5579,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
@@ -5597,16 +5726,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -5621,9 +5750,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -5648,10 +5777,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.6"
+name = "webpki-root-certs"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5662,7 +5791,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5917,7 +6046,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -5947,8 +6076,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
- "indexmap 2.13.0",
+ "bitflags 2.11.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5967,7 +6096,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -5982,6 +6111,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=aac27678a717deef473e98b026ce54dbf8a4670b#aac27678a717deef473e98b026ce54dbf8a4670b"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=32323566972e9f574ab9a90ba411a63b35dad86a#32323566972e9f574ab9a90ba411a63b35dad86a"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=aac27678a717deef473e98b026ce54dbf8a4670b#aac27678a717deef473e98b026ce54dbf8a4670b"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=32323566972e9f574ab9a90ba411a63b35dad86a#32323566972e9f574ab9a90ba411a63b35dad86a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=aac27678a717deef473e98b026ce54dbf8a4670b#aac27678a717deef473e98b026ce54dbf8a4670b"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=32323566972e9f574ab9a90ba411a63b35dad86a#32323566972e9f574ab9a90ba411a63b35dad86a"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=aac27678a717deef473e98b026ce54dbf8a4670b#aac27678a717deef473e98b026ce54dbf8a4670b"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=32323566972e9f574ab9a90ba411a63b35dad86a#32323566972e9f574ab9a90ba411a63b35dad86a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=aac27678a717deef473e98b026ce54dbf8a4670b#aac27678a717deef473e98b026ce54dbf8a4670b"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=32323566972e9f574ab9a90ba411a63b35dad86a#32323566972e9f574ab9a90ba411a63b35dad86a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,6 +3017,7 @@ dependencies = [
  "iceberg-catalog-rest",
  "iceberg-compaction-core",
  "iceberg-datafusion",
+ "iceberg-storage-opendal",
  "parquet",
  "port_scanner",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ datafusion = "54.1"
 # Local workspace members
 futures = "0.3.17"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "32323566972e9f574ab9a90ba411a63b35dad86a" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "32323566972e9f574ab9a90ba411a63b35dad86a" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "32323566972e9f574ab9a90ba411a63b35dad86a" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "32323566972e9f574ab9a90ba411a63b35dad86a" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7dc1d44994b16fa6893f7983da84dd3dc55e8e9a" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7dc1d44994b16fa6893f7983da84dd3dc55e8e9a" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7dc1d44994b16fa6893f7983da84dd3dc55e8e9a" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7dc1d44994b16fa6893f7983da84dd3dc55e8e9a" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "32323566972e9f574ab9a90ba411a63b35dad86a" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "32323566972e9f574ab9a90ba411a63b35dad86a", features = [
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7dc1d44994b16fa6893f7983da84dd3dc55e8e9a" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7dc1d44994b16fa6893f7983da84dd3dc55e8e9a", features = [
     "opendal-s3",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ datafusion = "54.1"
 # Local workspace members
 futures = "0.3.17"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "aac27678a717deef473e98b026ce54dbf8a4670b" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "aac27678a717deef473e98b026ce54dbf8a4670b" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "aac27678a717deef473e98b026ce54dbf8a4670b" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "aac27678a717deef473e98b026ce54dbf8a4670b" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "32323566972e9f574ab9a90ba411a63b35dad86a" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "32323566972e9f574ab9a90ba411a63b35dad86a" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "32323566972e9f574ab9a90ba411a63b35dad86a" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "32323566972e9f574ab9a90ba411a63b35dad86a" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "aac27678a717deef473e98b026ce54dbf8a4670b" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "aac27678a717deef473e98b026ce54dbf8a4670b", features = [
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "32323566972e9f574ab9a90ba411a63b35dad86a" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "32323566972e9f574ab9a90ba411a63b35dad86a", features = [
     "opendal-s3",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ datafusion = "54.1"
 # Local workspace members
 futures = "0.3.17"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7dc1d44994b16fa6893f7983da84dd3dc55e8e9a" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7dc1d44994b16fa6893f7983da84dd3dc55e8e9a" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7dc1d44994b16fa6893f7983da84dd3dc55e8e9a" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7dc1d44994b16fa6893f7983da84dd3dc55e8e9a" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7dc1d44994b16fa6893f7983da84dd3dc55e8e9a" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7dc1d44994b16fa6893f7983da84dd3dc55e8e9a", features = [
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590", features = [
     "opendal-s3",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,27 @@ async-trait = "0.1.89"
 
 # Data processing and storage
 ctor = "0.2.8"
-datafusion = "53.0"
+datafusion = "54.1"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4" }
+# branch dev_rebase_main_20260807
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "4cbd183953f89d7179b64072940a98232b958307" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "4cbd183953f89d7179b64072940a98232b958307" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "4cbd183953f89d7179b64072940a98232b958307" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "4cbd183953f89d7179b64072940a98232b958307" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "4cbd183953f89d7179b64072940a98232b958307" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "4cbd183953f89d7179b64072940a98232b958307", features = [
+    "opendal-azblob",
+    "opendal-azdls",
+    "opendal-fs",
+    "opendal-gcs",
+    "opendal-memory",
+    "opendal-s3",
+] }
 
-parquet = { version = "58.1", features = ["async"] }
+parquet = { version = "58.4", features = ["async"] }
 port_scanner = "0.1.5"
 rand = "0.9.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,6 @@ iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.g
 iceberg-compaction-core = { path = "./core" }
 iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "4cbd183953f89d7179b64072940a98232b958307" }
 iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "4cbd183953f89d7179b64072940a98232b958307", features = [
-    "opendal-azblob",
-    "opendal-azdls",
-    "opendal-fs",
-    "opendal-gcs",
-    "opendal-memory",
     "opendal-s3",
 ] }
 

--- a/core/src/compaction/auto.rs
+++ b/core/src/compaction/auto.rs
@@ -470,7 +470,7 @@ impl AutoCompaction {
 
 #[cfg(test)]
 mod tests {
-    use iceberg::spec::{DataContentType, DataFileFormat, Schema};
+    use iceberg::spec::{DataFileFormat, Schema};
 
     use super::*;
 
@@ -481,21 +481,22 @@ mod tests {
                 start: 0,
                 length,
                 record_count: Some(1),
+                first_row_id: None,
+                data_sequence_number: None,
                 data_file_path: path.to_owned(),
-                referenced_data_file: None,
-                data_file_content: DataContentType::Data,
                 data_file_format: DataFileFormat::Parquet,
                 schema: std::sync::Arc::new(Schema::builder().build().unwrap()),
                 project_field_ids: vec![],
                 predicate: None,
                 deletes: vec![],
                 sequence_number: 1,
-                equality_ids: None,
                 file_size_in_bytes: length,
                 partition: None,
                 partition_spec: None,
                 name_mapping: None,
+                unified_partition_type: None,
                 case_sensitive: true,
+                key_metadata: None,
             }
         }
 
@@ -508,21 +509,22 @@ mod tests {
             start: 0,
             length,
             record_count: Some(1),
+            first_row_id: None,
+            data_sequence_number: None,
             data_file_path: path.to_owned(),
-            referenced_data_file: None,
-            data_file_content: DataContentType::Data,
             data_file_format: DataFileFormat::Parquet,
             schema: std::sync::Arc::new(Schema::builder().build().unwrap()),
             project_field_ids: vec![],
             predicate: None,
             deletes: vec![],
             sequence_number: 1,
-            equality_ids: None,
             file_size_in_bytes: length,
             partition: None,
             partition_spec: None,
             name_mapping: None,
+            unified_partition_type: None,
             case_sensitive: true,
+            key_metadata: None,
         }
     }
 

--- a/core/src/compaction/mod.rs
+++ b/core/src/compaction/mod.rs
@@ -20,8 +20,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use backon::{ExponentialBuilder, Retryable};
-use iceberg::io::FileIO;
-use iceberg::spec::{DataFile, MAIN_BRANCH, Snapshot, UNASSIGNED_SNAPSHOT_ID};
+use iceberg::spec::{DataFile, MAIN_BRANCH, Snapshot};
 use iceberg::table::Table;
 use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::writer::file_writer::location_generator::DefaultLocationGenerator;
@@ -46,6 +45,8 @@ pub use auto::{
     AutoCompaction, AutoCompactionBuilder, AutoCompactionPlanner, AutoPlanReason, AutoPlanReport,
     AutoSelectedStrategy,
 };
+
+const UNASSIGNED_SNAPSHOT_ID: i64 = -1;
 
 /// Validates that all rewrite results target the same snapshot and branch.
 ///
@@ -528,7 +529,7 @@ impl Compaction {
     ) -> Result<Vec<RewriteResult>> {
         use futures::stream::{self, StreamExt};
 
-        let results: Result<Vec<RewriteResult>> = stream::iter(plans.into_iter())
+        let results: Result<Vec<RewriteResult>> = stream::iter(plans)
             .map(|plan| async move { self.rewrite_plan(plan, execution_config, table).await })
             .buffer_unordered(execution_config.max_concurrent_compaction_plans) // Limit concurrency based on config
             .collect::<Vec<_>>()
@@ -601,7 +602,7 @@ impl Compaction {
         execution_config: &CompactionExecutionConfig,
     ) -> Result<RewriteFilesRequest> {
         let schema = table.metadata().current_schema().clone();
-        let location_generator = DefaultLocationGenerator::new(table.metadata().clone()).unwrap();
+        let location_generator = DefaultLocationGenerator::new(table.metadata()).unwrap();
         let metrics_recorder = CompactionMetricsRecorder::new(
             self.metrics.clone(),
             self.catalog_name.clone(),
@@ -733,15 +734,17 @@ impl Compaction {
 /// Returns error if manifest list or manifest loading fails.
 async fn get_all_files_from_snapshot(
     snapshot: &Arc<Snapshot>,
-    file_io: &FileIO,
-    table_metadata: &iceberg::spec::TableMetadata,
+    table: &Table,
 ) -> Result<(Vec<DataFile>, Vec<DataFile>)> {
-    let manifest_list = snapshot.load_manifest_list(file_io, table_metadata).await?;
+    let manifest_list = table
+        .object_cache()
+        .get_manifest_list(snapshot, &table.metadata_ref())
+        .await?;
 
     let mut data_file = vec![];
     let mut delete_file = vec![];
     for manifest_file in manifest_list.entries() {
-        let a = manifest_file.load_manifest(file_io).await?;
+        let a = manifest_file.load_manifest(table.file_io()).await?;
         let (entry, _) = a.into_parts();
         for i in entry {
             match i.content_type() {
@@ -879,7 +882,7 @@ impl CommitManager {
 
         // 1. Load all files from snapshot once
         let (all_data_files, _all_delete_files) =
-            get_all_files_from_snapshot(snapshot, table.file_io(), table.metadata()).await?;
+            get_all_files_from_snapshot(snapshot, &table).await?;
 
         // 2. Build efficient path -> DataFile index (only for data files)
         let data_file_index: HashMap<&str, &DataFile> =
@@ -1365,9 +1368,7 @@ mod tests {
     use datafusion::arrow::record_batch::RecordBatch;
     use iceberg::arrow::schema_to_arrow_schema;
     use iceberg::memory::{MEMORY_CATALOG_WAREHOUSE, MemoryCatalog, MemoryCatalogBuilder};
-    use iceberg::spec::{
-        DataFile, MAIN_BRANCH, NestedField, PrimitiveType, Schema, Type, UNASSIGNED_SNAPSHOT_ID,
-    };
+    use iceberg::spec::{DataFile, MAIN_BRANCH, NestedField, PrimitiveType, Schema, Type};
     use iceberg::table::Table;
     use iceberg::transaction::{ApplyTransactionAction, Transaction};
     use iceberg::writer::base_writer::data_file_writer::DataFileWriterBuilder;
@@ -1390,7 +1391,9 @@ mod tests {
     use uuid::Uuid;
 
     // Additional imports for new tests
-    use crate::compaction::{CommitManagerRetryConfig, CompactionPlan, RewriteResult};
+    use crate::compaction::{
+        CommitManagerRetryConfig, CompactionPlan, RewriteResult, UNASSIGNED_SNAPSHOT_ID,
+    };
     use crate::compaction::{CompactionBuilder, CompactionPlanner};
     use crate::config::{
         CompactionConfigBuilder, CompactionExecutionConfigBuilder, CompactionPlanningConfig,
@@ -1685,8 +1688,9 @@ mod tests {
 
     async fn load_data_files_from_snapshot(table: &Table, branch: &str) -> Vec<DataFile> {
         let snapshot = table.metadata().snapshot_for_ref(branch).unwrap();
-        let manifest_list = snapshot
-            .load_manifest_list(table.file_io(), table.metadata())
+        let manifest_list = table
+            .object_cache()
+            .get_manifest_list(snapshot, &table.metadata_ref())
             .await
             .unwrap();
 

--- a/core/src/executor/datafusion/datafusion_processor.rs
+++ b/core/src/executor/datafusion/datafusion_processor.rs
@@ -130,6 +130,7 @@ impl DatafusionProcessor {
                         CompactionError::Unexpected("Position delete files are not set".to_owned())
                     })?,
                 &datafusion_task_ctx.position_delete_table_name(),
+                DataContentType::PositionDeletes,
             )?;
         }
 
@@ -147,6 +148,7 @@ impl DatafusionProcessor {
                     &equality_delete_schema,
                     file_scan_tasks,
                     &equality_delete_table_name,
+                    DataContentType::EqualityDeletes,
                 )?;
             }
         }
@@ -315,6 +317,7 @@ impl DatafusionTableRegister {
             schema,
             file_scan_tasks,
             table_name,
+            DataContentType::Data,
             need_seq_num,
             need_file_path_and_pos,
         )
@@ -325,8 +328,16 @@ impl DatafusionTableRegister {
         schema: &Schema,
         file_scan_tasks: Vec<FileScanTask>,
         table_name: &str,
+        file_type: DataContentType,
     ) -> Result<()> {
-        self.register_table_provider_impl(schema, file_scan_tasks, table_name, false, false)
+        self.register_table_provider_impl(
+            schema,
+            file_scan_tasks,
+            table_name,
+            file_type,
+            false,
+            false,
+        )
     }
 
     fn register_table_provider_impl(
@@ -334,12 +345,14 @@ impl DatafusionTableRegister {
         schema: &Schema,
         file_scan_tasks: Vec<FileScanTask>,
         table_name: &str,
+        file_type: DataContentType,
         need_seq_num: bool,
         need_file_path_and_pos: bool,
     ) -> Result<()> {
         let schema = schema_to_arrow_schema(schema)?;
         let data_file_table_provider = IcebergFileScanTaskTableProvider::new(
             file_scan_tasks,
+            file_type,
             Arc::new(schema),
             self.file_io.clone(),
             need_seq_num,
@@ -636,14 +649,12 @@ impl DataFusionTaskContextBuilder {
             .map(|mut task| {
                 if self.ge_v3_format() {
                     // Keep position deletes for reader-side filtering; drop equality deletes for joins.
-                    task.deletes.retain(|delete| {
-                        delete.data_file_content == DataContentType::PositionDeletes
-                    });
+                    task.deletes
+                        .retain(|delete| delete.file_type == DataContentType::PositionDeletes);
                 } else {
                     // Prevent ArrowReader from applying deletes; compaction handles them explicitly.
                     task.deletes.clear();
                 }
-                task.equality_ids = None;
                 task
             })
             .collect();
@@ -701,9 +712,13 @@ impl DataFusionTaskContextBuilder {
         let mut prev_equality_ids: Option<Vec<i32>> = None;
         let mut equality_delete_metadatas = Vec::new();
         for (table_idx, task) in self.equality_delete_files.iter().enumerate() {
-            let task_equality_ids = task.equality_ids.as_ref().ok_or_else(|| {
-                CompactionError::Execution("Equality delete file missing equality_ids".to_owned())
-            })?;
+            let task_equality_ids = (!task.project_field_ids.is_empty())
+                .then_some(task.project_field_ids.as_slice())
+                .ok_or_else(|| {
+                    CompactionError::Execution(
+                        "Equality delete file missing equality_ids".to_owned(),
+                    )
+                })?;
 
             if prev_equality_ids
                 .as_ref()
@@ -718,7 +733,7 @@ impl DataFusionTaskContextBuilder {
                     equality_delete_schema,
                     equality_delete_table_name,
                 ));
-                prev_equality_ids = Some(task_equality_ids.clone());
+                prev_equality_ids = Some(task_equality_ids.to_vec());
             }
 
             // Add the file scan task to the last metadata
@@ -963,11 +978,9 @@ mod tests {
     /// unbounded pool.
     #[test]
     fn test_new_with_memory_budget_builds_spilling_context() {
-        use iceberg::io::FileIOBuilder;
-
         use crate::config::CompactionExecutionConfigBuilder;
 
-        let file_io = FileIOBuilder::new("memory").build().unwrap();
+        let file_io = FileIO::new_with_memory();
 
         let bounded = Arc::new(
             CompactionExecutionConfigBuilder::default()

--- a/core/src/executor/datafusion/file_scan_task_table_provider.rs
+++ b/core/src/executor/datafusion/file_scan_task_table_provider.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use std::any::Any;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -26,6 +25,7 @@ use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
 use datafusion::physical_plan::ExecutionPlan;
 use iceberg::io::FileIO;
 use iceberg::scan::FileScanTask;
+use iceberg::spec::DataContentType;
 
 use super::iceberg_file_task_scan::IcebergFileTaskScan;
 
@@ -33,6 +33,7 @@ use super::iceberg_file_task_scan::IcebergFileTaskScan;
 #[derive(Debug, Clone)]
 pub struct IcebergFileScanTaskTableProvider {
     file_scan_tasks: Vec<FileScanTask>,
+    file_type: DataContentType,
     schema: ArrowSchemaRef,
     file_io: FileIO,
     need_seq_num: bool,
@@ -45,6 +46,7 @@ impl IcebergFileScanTaskTableProvider {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         file_scan_tasks: Vec<FileScanTask>,
+        file_type: DataContentType,
         schema: ArrowSchemaRef,
         file_io: FileIO,
         need_seq_num: bool,
@@ -55,6 +57,7 @@ impl IcebergFileScanTaskTableProvider {
     ) -> Self {
         Self {
             file_scan_tasks,
+            file_type,
             schema,
             file_io,
             need_seq_num,
@@ -67,10 +70,6 @@ impl IcebergFileScanTaskTableProvider {
 }
 #[async_trait]
 impl TableProvider for IcebergFileScanTaskTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> ArrowSchemaRef {
         self.schema.clone()
     }
@@ -92,6 +91,7 @@ impl TableProvider for IcebergFileScanTaskTableProvider {
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(IcebergFileTaskScan::new(
             self.file_scan_tasks.clone(),
+            self.file_type,
             self.schema.clone(),
             projection,
             filters,

--- a/core/src/executor/datafusion/iceberg_file_task_scan.rs
+++ b/core/src/executor/datafusion/iceberg_file_task_scan.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use std::any::Any;
 use std::collections::BinaryHeap;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -35,13 +34,16 @@ use datafusion::prelude::Expr;
 use futures::{Stream, StreamExt, TryStreamExt};
 use iceberg::arrow::ArrowReaderBuilder;
 use iceberg::expr::Predicate;
-use iceberg::io::{FileIO, FileIOBuilder};
+use iceberg::io::FileIO;
+use iceberg::metadata_columns::{
+    RESERVED_FIELD_ID_DELETE_FILE_PATH, RESERVED_FIELD_ID_DELETE_FILE_POS,
+};
 use iceberg::scan::FileScanTask;
 use iceberg::spec::DataContentType;
-use iceberg_datafusion::physical_plan::expr_to_predicate::convert_filters_to_predicate;
+use iceberg_datafusion::physical_plan::convert_filters_to_predicate;
 use iceberg_datafusion::to_datafusion_error;
 
-use super::datafusion_processor::SYS_HIDDEN_SEQ_NUM;
+use super::datafusion_processor::{SYS_HIDDEN_FILE_PATH, SYS_HIDDEN_POS, SYS_HIDDEN_SEQ_NUM};
 
 struct RecordBatchBuffer {
     buffer: Vec<RecordBatch>,
@@ -145,6 +147,7 @@ impl RecordBatchBuffer {
 #[derive(Debug)]
 pub(crate) struct IcebergFileTaskScan {
     file_scan_tasks_group: Vec<Vec<FileScanTask>>,
+    file_type: DataContentType,
     plan_properties: Arc<PlanProperties>,
     projection: Option<Vec<String>>,
     predicates: Option<Predicate>,
@@ -159,6 +162,7 @@ impl IcebergFileTaskScan {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         file_scan_tasks: Vec<FileScanTask>,
+        file_type: DataContentType,
         schema: ArrowSchemaRef,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
@@ -180,13 +184,21 @@ impl IcebergFileTaskScan {
                 .map(|mut task| {
                     let project_field_ids = projection
                         .iter()
-                        .filter_map(|name| task.schema().field_id_by_name(name))
+                        .filter_map(|name| match (file_type, name.as_str()) {
+                            (DataContentType::PositionDeletes, SYS_HIDDEN_FILE_PATH) => {
+                                Some(RESERVED_FIELD_ID_DELETE_FILE_PATH)
+                            }
+                            (DataContentType::PositionDeletes, SYS_HIDDEN_POS) => {
+                                Some(RESERVED_FIELD_ID_DELETE_FILE_POS)
+                            }
+                            _ => task.schema().field_id_by_name(name),
+                        })
                         .collect::<Vec<_>>();
                     let new_schema = iceberg::spec::Schema::builder()
                         .with_fields(
-                            projection
+                            project_field_ids
                                 .iter()
-                                .filter_map(|name| task.schema().field_by_name(name).cloned()),
+                                .filter_map(|id| task.schema().field_by_id(*id).cloned()),
                         )
                         .build()
                         .map_err(to_datafusion_error)?;
@@ -201,10 +213,25 @@ impl IcebergFileTaskScan {
         let file_scan_tasks_group = split_n_vecs(file_scan_tasks_projection, executor_parallelism);
         let plan_properties =
             Self::compute_properties(output_schema.clone(), file_scan_tasks_group.len());
-        let predicates = convert_filters_to_predicate(filters);
+        // Synthetic columns are appended after the Iceberg reader returns a
+        // batch, so predicates that reference them cannot be evaluated by the
+        // reader against the physical file schema. DataFusion retains these
+        // filters because the provider reports inexact pushdown.
+        let pushdown_filters = filters
+            .iter()
+            .filter(|expr| {
+                expr.column_refs().iter().all(|column| {
+                    ![SYS_HIDDEN_SEQ_NUM, SYS_HIDDEN_FILE_PATH, SYS_HIDDEN_POS]
+                        .contains(&column.name.as_str())
+                })
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let predicates = convert_filters_to_predicate(&pushdown_filters);
 
         Ok(Self {
             file_scan_tasks_group,
+            file_type,
             plan_properties,
             projection,
             predicates,
@@ -305,10 +332,6 @@ impl ExecutionPlan for IcebergFileTaskScan {
         "IcebergFileTaskScan"
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan + 'static>> {
         vec![]
     }
@@ -332,6 +355,7 @@ impl ExecutionPlan for IcebergFileTaskScan {
         let fut = get_batch_stream(
             self.file_io.clone(),
             self.file_scan_tasks_group[partition].clone(),
+            self.file_type,
             self.need_seq_num,
             self.need_file_path_and_pos,
             self.max_record_batch_rows,
@@ -355,10 +379,11 @@ impl ExecutionPlan for IcebergFileTaskScan {
 ///
 /// For now, only one file is processed at a time. Subsequent calls to the stream will
 /// eventually trigger more I/O reads.
-#[allow(clippy::unused_async)]
+#[allow(clippy::too_many_arguments, clippy::unused_async)]
 async fn get_batch_stream(
     file_io: FileIO,
     file_scan_tasks: Vec<FileScanTask>,
+    file_type: DataContentType,
     need_seq_num: bool,
     need_file_path_and_pos: bool,
     max_record_batch_rows: usize,
@@ -386,7 +411,7 @@ async fn get_batch_stream(
             MemoryConsumer::new("IcebergFileTaskScan[prefetch]").register(&memory_pool);
 
         for task in file_scan_tasks {
-            let mut file_context = FileTaskContext::from_task(&task);
+            let mut file_context = FileTaskContext::from_task(&task, file_type);
 
             let (file_io, task) = match &optional_prefetch {
                 // Prefetch stages ONLY the data file into the in-memory `FileIO`, and the
@@ -417,10 +442,13 @@ async fn get_batch_stream(
             };
 
             let task_stream = futures::stream::iter(vec![Ok(task)]).boxed();
-            let arrow_reader_builder = ArrowReaderBuilder::new(file_io).with_batch_size(max_record_batch_rows);
+            let runtime = iceberg::Runtime::try_current().map_err(to_datafusion_error)?;
+            let arrow_reader_builder = ArrowReaderBuilder::new(file_io, runtime)
+                .with_batch_size(max_record_batch_rows);
             let mut batch_stream = arrow_reader_builder.build()
                 .read(task_stream)
-                .map_err(to_datafusion_error)?;
+                .map_err(to_datafusion_error)?
+                .stream();
 
             let mut index_start = 0;
             while let Some(batch) = batch_stream.next().await {
@@ -474,10 +502,10 @@ struct FileTaskContext {
 }
 
 impl FileTaskContext {
-    fn from_task(task: &FileScanTask) -> Self {
+    fn from_task(task: &FileScanTask, file_type: DataContentType) -> Self {
         Self {
             original_path: task.data_file_path.clone(),
-            data_file_content: task.data_file_content,
+            data_file_content: file_type,
             sequence_number: task.sequence_number,
             memory_path: None,
         }
@@ -497,9 +525,7 @@ struct Prefetcher {
 impl Prefetcher {
     fn new() -> DFResult<Self> {
         Ok(Self {
-            memory_file_io: FileIOBuilder::new("memory")
-                .build()
-                .map_err(|e| DataFusionError::External(Box::new(e)))?,
+            memory_file_io: FileIO::new_with_memory(),
         })
     }
 
@@ -691,7 +717,7 @@ mod tests {
     use std::sync::Arc;
 
     use datafusion::arrow::datatypes::{DataType as ArrowDataType, SchemaBuilder};
-    use iceberg::scan::FileScanTask;
+    use iceberg::scan::{FileScanTask, FileScanTaskDeleteFile};
     use iceberg::spec::{DataContentType, Schema};
 
     use super::*;
@@ -701,21 +727,22 @@ mod tests {
             length,
             start: 0,
             record_count: Some(0),
+            first_row_id: None,
+            data_sequence_number: None,
             data_file_path: format!("test_{}.parquet", file_id),
-            referenced_data_file: None,
-            data_file_content: DataContentType::Data,
             data_file_format: iceberg::spec::DataFileFormat::Parquet,
             schema: Arc::new(Schema::builder().build().unwrap()),
             project_field_ids: vec![],
             predicate: None,
             deletes: vec![],
             sequence_number: 0,
-            equality_ids: None,
             file_size_in_bytes: length,
             partition: None,
             partition_spec: None,
             name_mapping: None,
+            unified_partition_type: None,
             case_sensitive: true,
+            key_metadata: None,
         }
     }
 
@@ -1089,7 +1116,7 @@ mod tests {
         use datafusion::execution::memory_pool::{FairSpillPool, UnboundedMemoryPool};
 
         // A source file living in an in-memory FileIO that the prefetcher reads from.
-        let source_io = FileIOBuilder::new("memory").build().unwrap();
+        let source_io = FileIO::new_with_memory();
         let source_path = "memory:/src/prefetch_budget_test.bin";
         let file_len = 1024 * 1024; // 1 MiB
         source_io
@@ -1113,7 +1140,7 @@ mod tests {
             let mut reservation = MemoryConsumer::new("test[prefetch]").register(&pool);
 
             let task = make_task();
-            let mut ctx = FileTaskContext::from_task(&task);
+            let mut ctx = FileTaskContext::from_task(&task, DataContentType::Data);
             let err = prefetcher
                 .prefetch_file_into_memory(&task, &mut ctx, &source_io, &mut reservation)
                 .await
@@ -1134,7 +1161,7 @@ mod tests {
             let mut reservation = MemoryConsumer::new("test[prefetch]").register(&pool);
 
             let task = make_task();
-            let mut ctx = FileTaskContext::from_task(&task);
+            let mut ctx = FileTaskContext::from_task(&task, DataContentType::Data);
             prefetcher
                 .prefetch_file_into_memory(&task, &mut ctx, &source_io, &mut reservation)
                 .await
@@ -1158,7 +1185,7 @@ mod tests {
         // attempted -- so seeing that error (rather than an IO error against the
         // missing file) proves the read never started.
         let prefetcher = Prefetcher::new().unwrap();
-        let empty_source_io = FileIOBuilder::new("memory").build().unwrap();
+        let empty_source_io = FileIO::new_with_memory();
 
         let declared_len = 1024 * 1024; // 1 MiB, larger than the pool below
         let mut task = create_file_scan_task(declared_len, 1);
@@ -1167,7 +1194,7 @@ mod tests {
         let pool: Arc<dyn MemoryPool> = Arc::new(FairSpillPool::new(4 * 1024));
         let mut reservation = MemoryConsumer::new("test[prefetch]").register(&pool);
 
-        let mut ctx = FileTaskContext::from_task(&task);
+        let mut ctx = FileTaskContext::from_task(&task, DataContentType::Data);
         let err = prefetcher
             .prefetch_file_into_memory(&task, &mut ctx, &empty_source_io, &mut reservation)
             .await
@@ -1189,15 +1216,21 @@ mod tests {
         path: &str,
         format: iceberg::spec::DataFileFormat,
         referenced_data_file: Option<String>,
-    ) -> Arc<FileScanTask> {
-        let mut task = create_file_scan_task(64, 900);
-        task.data_file_path = path.to_owned();
-        task.data_file_content = DataContentType::PositionDeletes;
-        task.data_file_format = format;
-        task.referenced_data_file = referenced_data_file;
-        task.start = 4;
-        task.length = 64;
-        Arc::new(task)
+    ) -> FileScanTaskDeleteFile {
+        FileScanTaskDeleteFile::builder()
+            .with_file_path(path.to_owned())
+            .with_file_size_in_bytes(64)
+            .with_file_type(DataContentType::PositionDeletes)
+            .with_partition_spec_id(0)
+            .with_file_format(format)
+            .with_referenced_data_file(referenced_data_file)
+            .with_content_offset((format == iceberg::spec::DataFileFormat::Puffin).then_some(4))
+            .with_content_size_in_bytes(
+                (format == iceberg::spec::DataFileFormat::Puffin).then_some(64),
+            )
+            .with_record_count(Some(10))
+            .with_sequence_number(1)
+            .build()
     }
 
     /// Prefetch must be declined for any task that carries delete files.

--- a/core/src/file_selection/mod.rs
+++ b/core/src/file_selection/mod.rs
@@ -50,25 +50,16 @@ impl FileSelector {
 
     /// Scans and collects all data files from a table snapshot.
     ///
-    /// Filters out non-data files (delete files). Returns raw `FileScanTask`s
-    /// for downstream processing.
+    /// Returns the data-file tasks planned for downstream processing.
+    ///
+    /// Iceberg's current scan API keeps delete files as lightweight descriptors
+    /// nested under each data task, so every top-level task is a data file.
     pub async fn scan_data_files(table: &Table, snapshot_id: i64) -> Result<Vec<FileScanTask>> {
         let scan = table.scan().snapshot_id(snapshot_id).build()?;
 
         let file_scan_stream = scan.plan_files().await?;
 
-        let data_files: Vec<FileScanTask> = file_scan_stream
-            .try_filter_map(|task| {
-                futures::future::ready(Ok(
-                    if matches!(task.data_file_content, iceberg::spec::DataContentType::Data) {
-                        Some(task)
-                    } else {
-                        None
-                    },
-                ))
-            })
-            .try_collect()
-            .await?;
+        let data_files: Vec<FileScanTask> = file_scan_stream.try_collect().await?;
         Ok(data_files)
     }
 

--- a/core/src/file_selection/strategy.rs
+++ b/core/src/file_selection/strategy.rs
@@ -34,8 +34,9 @@ use crate::{CompactionError, Result};
 
 /// Bundle of data files and associated delete files for compaction.
 ///
-/// Delete files are deduplicated by path during construction. Position deletes
-/// have `project_field_ids` cleared; equality deletes use `equality_ids`.
+/// Delete files are deduplicated by physical file/blob identity during construction.
+/// Position deletes use Iceberg's fixed delete schema; equality deletes use their
+/// descriptor's `equality_ids`.
 ///
 /// # Fields
 /// - `total_size`: Sum of `data_files[*].length` (excludes delete file sizes)
@@ -56,31 +57,40 @@ pub struct FileGroup {
 impl FileGroup {
     /// Constructs a `FileGroup` from data files.
     ///
-    /// Deduplicates delete files by `data_file_path`. Position delete files have
-    /// `project_field_ids` reset to empty; equality delete files copy `equality_ids`
-    /// to `project_field_ids`.
+    /// Deduplicates delete files by path plus optional Puffin byte range. Position
+    /// delete files use Iceberg's fixed delete projection; equality delete files
+    /// copy descriptor `equality_ids` to `project_field_ids`.
     ///
     /// Sets `executor_parallelism` and `output_parallelism` to 1.
     pub fn new(data_files: Vec<FileScanTask>) -> Self {
         let total_size = data_files.iter().map(|task| task.length).sum();
         let data_file_count = data_files.len();
 
-        // De-duplicate delete files by path
-        let mut position_delete_map = std::collections::HashMap::new();
-        let mut equality_delete_map = std::collections::HashMap::new();
+        // A Puffin file can contain multiple deletion-vector blobs, so path alone
+        // is not a sufficient identity.
+        let mut position_delete_map = HashMap::new();
+        let mut equality_delete_map = HashMap::new();
 
         for task in &data_files {
             for delete_task in &task.deletes {
-                match &delete_task.data_file_content {
+                let identity = (
+                    delete_task.file_path.clone(),
+                    delete_task.content_offset,
+                    delete_task.content_size_in_bytes,
+                );
+                let mut standalone_task = delete_task.to_file_scan_task(task);
+                match delete_task.file_type {
                     iceberg::spec::DataContentType::PositionDeletes => {
                         position_delete_map
-                            .entry(&delete_task.data_file_path)
-                            .or_insert(delete_task);
+                            .entry(identity)
+                            .or_insert(standalone_task);
                     }
                     iceberg::spec::DataContentType::EqualityDeletes => {
+                        standalone_task.project_field_ids =
+                            delete_task.equality_ids.clone().unwrap_or_default();
                         equality_delete_map
-                            .entry(&delete_task.data_file_path)
-                            .or_insert(delete_task);
+                            .entry(identity)
+                            .or_insert(standalone_task);
                     }
                     _ => {}
                 }
@@ -89,20 +99,10 @@ impl FileGroup {
 
         let position_delete_files = position_delete_map
             .into_values()
-            .map(|file| {
-                let mut file = file.as_ref().clone();
-                file.project_field_ids = vec![];
-                file
-            })
             .collect::<Vec<FileScanTask>>();
 
         let equality_delete_files = equality_delete_map
             .into_values()
-            .map(|file| {
-                let mut file = file.as_ref().clone();
-                file.project_field_ids = file.equality_ids.clone().unwrap_or_default();
-                file
-            })
             .collect::<Vec<FileScanTask>>();
 
         Self {
@@ -975,6 +975,8 @@ mod tests {
     // Lazy static schema to avoid rebuilding it for every test
     use std::sync::{Arc, OnceLock};
 
+    use iceberg::scan::FileScanTaskDeleteFile;
+
     use super::*;
     use crate::config::{
         CompactionPlanningConfig, FileGroupScope, FilesWithDeletesConfigBuilder,
@@ -1038,8 +1040,6 @@ mod tests {
         }
 
         pub fn build(self) -> FileScanTask {
-            use std::sync::Arc;
-
             use iceberg::spec::{DataContentType, DataFileFormat};
 
             let deletes = if self.has_deletes {
@@ -1047,38 +1047,24 @@ mod tests {
                     .into_iter()
                     .enumerate()
                     .map(|(i, delete_type)| {
-                        Arc::new(FileScanTask {
-                            start: 0,
-                            length: 1024,
-                            record_count: Some(10),
-                            data_file_path: format!(
+                        FileScanTaskDeleteFile::builder()
+                            .with_file_path(format!(
                                 "{}_{}_delete.parquet",
                                 self.path.replace(".parquet", ""),
                                 i
-                            ),
-                            referenced_data_file: None,
-                            data_file_content: delete_type,
-                            data_file_format: DataFileFormat::Parquet,
-                            schema: self.schema.clone().unwrap_or(get_test_schema()),
-                            project_field_ids: if delete_type == DataContentType::EqualityDeletes {
-                                vec![1, 2]
-                            } else {
-                                vec![1]
-                            },
-                            predicate: None,
-                            deletes: vec![],
-                            sequence_number: 1,
-                            equality_ids: if delete_type == DataContentType::EqualityDeletes {
+                            ))
+                            .with_file_size_in_bytes(1024)
+                            .with_file_type(delete_type)
+                            .with_partition_spec_id(0)
+                            .with_equality_ids(if delete_type == DataContentType::EqualityDeletes {
                                 Some(vec![1, 2])
                             } else {
                                 None
-                            },
-                            file_size_in_bytes: 1024,
-                            partition: None,
-                            partition_spec: None,
-                            name_mapping: None,
-                            case_sensitive: true,
-                        })
+                            })
+                            .with_file_format(DataFileFormat::Parquet)
+                            .with_record_count(Some(10))
+                            .with_sequence_number(1)
+                            .build()
                     })
                     .collect()
             } else {
@@ -1089,21 +1075,22 @@ mod tests {
                 start: 0,
                 length: self.size,
                 record_count: Some(100),
+                first_row_id: None,
+                data_sequence_number: None,
                 data_file_path: self.path,
-                referenced_data_file: None,
-                data_file_content: DataContentType::Data,
                 data_file_format: DataFileFormat::Parquet,
                 schema: self.schema.unwrap_or(get_test_schema()),
                 project_field_ids: vec![1, 2],
                 predicate: None,
                 deletes,
                 sequence_number: 1,
-                equality_ids: None,
                 file_size_in_bytes: self.size,
                 partition: self.partition,
                 partition_spec: None,
                 name_mapping: None,
+                unified_partition_type: None,
                 case_sensitive: true,
+                key_metadata: None,
             }
         }
     }
@@ -1144,28 +1131,21 @@ mod tests {
         pub fn create_delete_file(
             path: String,
             content_type: iceberg::spec::DataContentType,
-        ) -> Arc<FileScanTask> {
+        ) -> FileScanTaskDeleteFile {
             use iceberg::spec::DataFileFormat;
-            Arc::new(FileScanTask {
-                start: 0,
-                length: 1024,
-                record_count: Some(10),
-                data_file_path: path,
-                referenced_data_file: None,
-                data_file_content: content_type,
-                data_file_format: DataFileFormat::Parquet,
-                schema: get_test_schema(),
-                project_field_ids: vec![1, 2],
-                predicate: None,
-                deletes: vec![],
-                sequence_number: 1,
-                equality_ids: Some(vec![1, 2]),
-                file_size_in_bytes: 1024,
-                partition: None,
-                partition_spec: None,
-                name_mapping: None,
-                case_sensitive: true,
-            })
+            FileScanTaskDeleteFile::builder()
+                .with_file_path(path)
+                .with_file_size_in_bytes(1024)
+                .with_file_type(content_type)
+                .with_partition_spec_id(0)
+                .with_equality_ids(
+                    (content_type == iceberg::spec::DataContentType::EqualityDeletes)
+                        .then_some(vec![1, 2]),
+                )
+                .with_file_format(DataFileFormat::Parquet)
+                .with_record_count(Some(10))
+                .with_sequence_number(1)
+                .build()
         }
 
         /// Add n delete files to a `FileScanTask`
@@ -1932,73 +1912,25 @@ mod tests {
     #[test]
     fn test_file_group_delete_files_extraction() {
         // Test that FileGroup correctly extracts and organizes delete files
-        use std::sync::Arc;
-
-        use iceberg::spec::{DataContentType, DataFileFormat};
+        use iceberg::spec::DataContentType;
 
         // Create a data file with both position and equality delete files
-        let position_delete = Arc::new(FileScanTask {
-            start: 0,
-            length: 1024,
-            record_count: Some(10),
-            data_file_path: "pos_delete.parquet".to_owned(),
-            referenced_data_file: None,
-            data_file_content: DataContentType::PositionDeletes,
-            data_file_format: DataFileFormat::Parquet,
-            schema: get_test_schema(),
-            project_field_ids: vec![1],
-            predicate: None,
-            deletes: vec![],
-            sequence_number: 1,
-            equality_ids: None,
-            file_size_in_bytes: 1024,
-            partition: None,
-            partition_spec: None,
-            name_mapping: None,
-            case_sensitive: true,
-        });
+        let position_delete = TestUtils::create_delete_file(
+            "pos_delete.parquet".to_owned(),
+            DataContentType::PositionDeletes,
+        );
+        let mut equality_delete = TestUtils::create_delete_file(
+            "eq_delete.parquet".to_owned(),
+            DataContentType::EqualityDeletes,
+        );
+        equality_delete.file_size_in_bytes = 2048;
+        equality_delete.record_count = Some(20);
 
-        let equality_delete = Arc::new(FileScanTask {
-            start: 0,
-            length: 2048,
-            record_count: Some(20),
-            data_file_path: "eq_delete.parquet".to_owned(),
-            referenced_data_file: None,
-            data_file_content: DataContentType::EqualityDeletes,
-            data_file_format: DataFileFormat::Parquet,
-            schema: get_test_schema(),
-            project_field_ids: vec![1, 2],
-            predicate: None,
-            deletes: vec![],
-            sequence_number: 1,
-            equality_ids: Some(vec![1, 2]),
-            file_size_in_bytes: 2048,
-            partition: None,
-            partition_spec: None,
-            name_mapping: None,
-            case_sensitive: true,
-        });
-
-        let data_file = FileScanTask {
-            start: 0,
-            length: 10 * 1024 * 1024, // 10MB
-            record_count: Some(1000),
-            data_file_path: "data.parquet".to_owned(),
-            referenced_data_file: None,
-            data_file_content: DataContentType::Data,
-            data_file_format: DataFileFormat::Parquet,
-            schema: get_test_schema(),
-            project_field_ids: vec![1, 2],
-            predicate: None,
-            deletes: vec![position_delete, equality_delete],
-            sequence_number: 1,
-            equality_ids: None,
-            file_size_in_bytes: 10 * 1024 * 1024,
-            partition: None,
-            partition_spec: None,
-            name_mapping: None,
-            case_sensitive: true,
-        };
+        let mut data_file = TestFileBuilder::new("data.parquet")
+            .size(10 * 1024 * 1024)
+            .build();
+        data_file.record_count = Some(1000);
+        data_file.deletes = vec![position_delete, equality_delete];
 
         let group = FileGroup::new(vec![data_file]);
 
@@ -2026,72 +1958,23 @@ mod tests {
     #[test]
     fn test_file_group_delete_files_dedup_and_heuristic_output_parallelism() {
         // Build two data files referencing the same delete file path to ensure dedup
-        use std::sync::Arc;
+        use iceberg::spec::DataContentType;
 
-        use iceberg::spec::{DataContentType, DataFileFormat};
+        let mut shared_pos_delete = TestUtils::create_delete_file(
+            "shared_pos_delete.parquet".to_owned(),
+            DataContentType::PositionDeletes,
+        );
+        shared_pos_delete.file_size_in_bytes = 512;
 
-        let shared_pos_delete = Arc::new(FileScanTask {
-            start: 0,
-            length: 512,
-            record_count: Some(10),
-            data_file_path: "shared_pos_delete.parquet".to_owned(),
-            referenced_data_file: None,
-            data_file_content: DataContentType::PositionDeletes,
-            data_file_format: DataFileFormat::Parquet,
-            schema: get_test_schema(),
-            project_field_ids: vec![1],
-            predicate: None,
-            deletes: vec![],
-            sequence_number: 1,
-            equality_ids: None,
-            file_size_in_bytes: 512,
-            partition: None,
-            partition_spec: None,
-            name_mapping: None,
-            case_sensitive: true,
-        });
+        let mut f1 = TestFileBuilder::new("d1.parquet")
+            .size(4 * 1024 * 1024)
+            .build();
+        f1.deletes = vec![shared_pos_delete.clone()];
 
-        let f1 = FileScanTask {
-            start: 0,
-            length: 4 * 1024 * 1024,
-            record_count: Some(100),
-            data_file_path: "d1.parquet".to_owned(),
-            referenced_data_file: None,
-            data_file_content: DataContentType::Data,
-            data_file_format: DataFileFormat::Parquet,
-            schema: get_test_schema(),
-            project_field_ids: vec![1, 2],
-            predicate: None,
-            deletes: vec![shared_pos_delete.clone()],
-            sequence_number: 1,
-            equality_ids: None,
-            file_size_in_bytes: 4 * 1024 * 1024,
-            partition: None,
-            partition_spec: None,
-            name_mapping: None,
-            case_sensitive: true,
-        };
-
-        let f2 = FileScanTask {
-            start: 0,
-            length: 4 * 1024 * 1024,
-            record_count: Some(100),
-            data_file_path: "d2.parquet".to_owned(),
-            referenced_data_file: None,
-            data_file_content: DataContentType::Data,
-            data_file_format: DataFileFormat::Parquet,
-            schema: get_test_schema(),
-            project_field_ids: vec![1, 2],
-            predicate: None,
-            deletes: vec![shared_pos_delete],
-            sequence_number: 1,
-            equality_ids: None,
-            file_size_in_bytes: 4 * 1024 * 1024,
-            partition: None,
-            partition_spec: None,
-            name_mapping: None,
-            case_sensitive: true,
-        };
+        let mut f2 = TestFileBuilder::new("d2.parquet")
+            .size(4 * 1024 * 1024)
+            .build();
+        f2.deletes = vec![shared_pos_delete];
 
         let group = FileGroup::new(vec![f1, f2]);
         // Dedup should keep one position delete
@@ -2121,95 +2004,60 @@ mod tests {
     }
 
     #[test]
-    fn test_file_group_delete_files_dedup_mixed_types() {
-        // Test deduplication of equality deletes and mixed delete types
-        use std::sync::Arc;
-
+    fn test_file_group_keeps_distinct_puffin_blobs() {
         use iceberg::spec::{DataContentType, DataFileFormat};
 
-        let shared_eq_delete = Arc::new(FileScanTask {
-            start: 0,
-            length: 1024,
-            record_count: Some(5),
-            data_file_path: "shared_eq_delete.parquet".to_owned(),
-            referenced_data_file: None,
-            data_file_content: DataContentType::EqualityDeletes,
-            data_file_format: DataFileFormat::Parquet,
-            schema: get_test_schema(),
-            project_field_ids: vec![1, 2],
-            predicate: None,
-            deletes: vec![],
-            sequence_number: 1,
-            equality_ids: Some(vec![1, 2]),
-            file_size_in_bytes: 1024,
-            partition: None,
-            partition_spec: None,
-            name_mapping: None,
-            case_sensitive: true,
-        });
+        let mut first = TestUtils::create_delete_file(
+            "shared-dv.puffin".to_owned(),
+            DataContentType::PositionDeletes,
+        );
+        first.file_format = DataFileFormat::Puffin;
+        first.content_offset = Some(10);
+        first.content_size_in_bytes = Some(20);
 
-        let pos_delete = Arc::new(FileScanTask {
-            start: 0,
-            length: 512,
-            record_count: Some(3),
-            data_file_path: "pos_delete.parquet".to_owned(),
-            referenced_data_file: None,
-            data_file_content: DataContentType::PositionDeletes,
-            data_file_format: DataFileFormat::Parquet,
-            schema: get_test_schema(),
-            project_field_ids: vec![1],
-            predicate: None,
-            deletes: vec![],
-            sequence_number: 1,
-            equality_ids: None,
-            file_size_in_bytes: 512,
-            partition: None,
-            partition_spec: None,
-            name_mapping: None,
-            case_sensitive: true,
-        });
+        let mut second = first.clone();
+        second.content_offset = Some(40);
+        second.content_size_in_bytes = Some(30);
 
-        let f1 = FileScanTask {
-            start: 0,
-            length: 5 * 1024 * 1024,
-            record_count: Some(100),
-            data_file_path: "d1.parquet".to_owned(),
-            referenced_data_file: None,
-            data_file_content: DataContentType::Data,
-            data_file_format: DataFileFormat::Parquet,
-            schema: get_test_schema(),
-            project_field_ids: vec![1, 2],
-            predicate: None,
-            deletes: vec![shared_eq_delete.clone(), pos_delete.clone()],
-            sequence_number: 1,
-            equality_ids: None,
-            file_size_in_bytes: 5 * 1024 * 1024,
-            partition: None,
-            partition_spec: None,
-            name_mapping: None,
-            case_sensitive: true,
-        };
+        let mut data_file = TestFileBuilder::new("data.parquet").build();
+        data_file.deletes = vec![first, second];
 
-        let f2 = FileScanTask {
-            start: 0,
-            length: 5 * 1024 * 1024,
-            record_count: Some(100),
-            data_file_path: "d2.parquet".to_owned(),
-            referenced_data_file: None,
-            data_file_content: DataContentType::Data,
-            data_file_format: DataFileFormat::Parquet,
-            schema: get_test_schema(),
-            project_field_ids: vec![1, 2],
-            predicate: None,
-            deletes: vec![shared_eq_delete, pos_delete],
-            sequence_number: 1,
-            equality_ids: None,
-            file_size_in_bytes: 5 * 1024 * 1024,
-            partition: None,
-            partition_spec: None,
-            name_mapping: None,
-            case_sensitive: true,
-        };
+        let mut ranges = FileGroup::new(vec![data_file])
+            .position_delete_files
+            .into_iter()
+            .map(|task| (task.start, task.length))
+            .collect::<Vec<_>>();
+        ranges.sort_unstable();
+
+        assert_eq!(ranges, vec![(10, 20), (40, 30)]);
+    }
+
+    #[test]
+    fn test_file_group_delete_files_dedup_mixed_types() {
+        // Test deduplication of equality deletes and mixed delete types
+        use iceberg::spec::DataContentType;
+
+        let mut shared_eq_delete = TestUtils::create_delete_file(
+            "shared_eq_delete.parquet".to_owned(),
+            DataContentType::EqualityDeletes,
+        );
+        shared_eq_delete.record_count = Some(5);
+        let mut pos_delete = TestUtils::create_delete_file(
+            "pos_delete.parquet".to_owned(),
+            DataContentType::PositionDeletes,
+        );
+        pos_delete.file_size_in_bytes = 512;
+        pos_delete.record_count = Some(3);
+
+        let mut f1 = TestFileBuilder::new("d1.parquet")
+            .size(5 * 1024 * 1024)
+            .build();
+        f1.deletes = vec![shared_eq_delete.clone(), pos_delete.clone()];
+
+        let mut f2 = TestFileBuilder::new("d2.parquet")
+            .size(5 * 1024 * 1024)
+            .build();
+        f2.deletes = vec![shared_eq_delete, pos_delete];
 
         let group = FileGroup::new(vec![f1, f2]);
 

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = "1.0"
 iceberg = { workspace = true }
 # iceberg-catalog-memory = { workspace = true }
 iceberg-catalog-rest = { workspace = true }
+iceberg-storage-opendal = { workspace = true }
 # Main library
 iceberg-compaction-core = { path = "../core" }
 iceberg-datafusion = { workspace = true }

--- a/integration-tests/src/docker_compose.rs
+++ b/integration-tests/src/docker_compose.rs
@@ -18,11 +18,12 @@
 use core::net::{IpAddr, SocketAddr};
 use std::collections::HashMap;
 use std::process::Command;
-use std::sync::{Once, RwLock};
+use std::sync::{Arc, Once, RwLock};
 
 use ctor::dtor;
 use iceberg_catalog_rest::{REST_CATALOG_PROP_URI, RestCatalog, RestCatalogBuilder};
 use iceberg_compaction_core::iceberg::CatalogBuilder;
+use iceberg_storage_opendal::OpenDalStorageFactory;
 use port_scanner::scan_port_addr;
 
 const REST_CATALOG_PORT: u16 = 8181;
@@ -38,6 +39,7 @@ pub const S3_ACCESS_KEY_ID: &str = "s3.access-key-id";
 pub const S3_SECRET_ACCESS_KEY: &str = "s3.secret-access-key";
 pub const S3_REGION: &str = "s3.region";
 const S3_ENDPOINT: &str = "s3.endpoint";
+const S3_PATH_STYLE_ACCESS: &str = "s3.path-style-access";
 
 const DEFAULT_ADMIN: &str = "admin";
 const DEFAULT_PASSWORD: &str = "password";
@@ -112,6 +114,7 @@ pub async fn get_rest_catalog() -> RestCatalog {
                 aws_region.unwrap_or(DEFAULT_REGION.to_owned()),
             ),
             (S3_ENDPOINT.to_owned(), aws_endpoint),
+            (S3_PATH_STYLE_ACCESS.to_owned(), "true".to_owned()),
         ]);
         let rest_catalog_ip = docker_compose.get_container_ip(REST_SERVICE);
         (rest_catalog_ip, props)
@@ -129,6 +132,9 @@ pub async fn get_rest_catalog() -> RestCatalog {
         format!("http://{}", rest_socket_addr),
     );
     RestCatalogBuilder::default()
+        .with_storage_factory(Arc::new(OpenDalStorageFactory::S3 {
+            customized_credential_load: None,
+        }))
         .load("rest", props)
         .await
         .expect("rest catalog build failed")

--- a/integration-tests/src/test_utils/generator.rs
+++ b/integration-tests/src/test_utils/generator.rs
@@ -523,16 +523,16 @@ impl FileGenerator {
         let writer_builder = SharedIcebergWriterBuilder::new(self.build_delta_writer_builder()?);
         let mut writer = self.create_task_writer(writer_builder.clone())?;
 
-        let equality_delete_rate = if self.config.equality_delete_row_count == 0 {
-            None
-        } else {
-            Some(self.config.data_file_row_count / self.config.equality_delete_row_count + 1)
-        };
-        let position_delete_rate = if self.config.position_delete_row_count == 0 {
-            None
-        } else {
-            Some(self.config.data_file_row_count / self.config.position_delete_row_count + 1)
-        };
+        let equality_delete_rate = self
+            .config
+            .data_file_row_count
+            .checked_div(self.config.equality_delete_row_count)
+            .map(|rate| rate + 1);
+        let position_delete_rate = self
+            .config
+            .data_file_row_count
+            .checked_div(self.config.position_delete_row_count)
+            .map(|rate| rate + 1);
 
         let mut data_file_num = 0;
 

--- a/integration-tests/src/test_utils/mod.rs
+++ b/integration-tests/src/test_utils/mod.rs
@@ -25,6 +25,7 @@ use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::{Catalog, CatalogBuilder, NamespaceIdent, TableCreation};
 use iceberg_catalog_rest::{REST_CATALOG_PROP_URI, RestCatalog};
 use iceberg_compaction_core::error::Result;
+use iceberg_storage_opendal::OpenDalStorageFactory;
 use serde::{Deserialize, Serialize};
 
 use crate::test_utils::generator::{FileGenerator, FileGeneratorConfig, WriterConfig};
@@ -83,6 +84,9 @@ impl MockRestCatalogConfig {
         props.insert(S3_REGION.to_owned(), self.s3_region.clone());
         props.insert(REST_CATALOG_PROP_URI.to_owned(), self.catalog_uri.clone());
         iceberg_compaction_core::iceberg_catalog_rest::RestCatalogBuilder::default()
+            .with_storage_factory(Arc::new(OpenDalStorageFactory::S3 {
+                customized_credential_load: None,
+            }))
             .load("rest", props)
             .await
             .expect("failed to build rest catalog")

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-10-10"
+channel = "nightly-2026-03-05"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- bump all iceberg-rust dependencies to the current `dev_rebase_main_20260807` head at `7dc1d44994b16fa6893f7983da84dd3dc55e8e9a`
- include the merged Glue timestamp mapping, factory-scoped OpenDAL operator cache, and expired snapshot metadata cleanup fixes
- adapt compaction and DataFusion scan code to the current iceberg-rust scan, object-cache, delete-file, and storage-factory APIs
- preserve position/equality delete handling, including distinct Puffin blob ranges
- align DataFusion/Arrow and the Rust toolchain with the new iceberg-rust baseline

## Dependency chain

- upstream dependency branch: https://github.com/risingwavelabs/iceberg-rust/tree/dev_rebase_main_20260807
- expired metadata cleanup follow-up: https://github.com/risingwavelabs/iceberg-rust/pull/211
- upstream tracking issue: https://github.com/risingwavelabs/iceberg-rust/issues/191
- downstream RisingWave PR: https://github.com/risingwavelabs/risingwave/pull/26619

## Validation

- `cargo check --locked --workspace --all-targets`
- `make check` (rustfmt, Clippy with `-D warnings`, Taplo)
- `make unit-test` (135 passed)
- GitHub CI: Check, Build, Unit Test, and Integration Test all passed
