### PR TITLE
chore: bump iceberg-rust to deb4a3c8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=deb4a3c8d5277b76d60f43ecaf6d598b0de50873#deb4a3c8d5277b76d60f43ecaf6d598b0de50873"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=deb4a3c8d5277b76d60f43ecaf6d598b0de50873#deb4a3c8d5277b76d60f43ecaf6d598b0de50873"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=deb4a3c8d5277b76d60f43ecaf6d598b0de50873#deb4a3c8d5277b76d60f43ecaf6d598b0de50873"
 dependencies = [
  "async-trait",
  "base64",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=6bd8e98fe920def857f80024f5a666c9631e80f4#6bd8e98fe920def857f80024f5a666c9631e80f4"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=deb4a3c8d5277b76d60f43ecaf6d598b0de50873#deb4a3c8d5277b76d60f43ecaf6d598b0de50873"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ datafusion = "53.0"
 
 # Local workspace members
 futures = "0.3.17"
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "deb4a3c8d5277b76d60f43ecaf6d598b0de50873", features = ["storage-s3", "storage-gcs", "storage-azblob", "storage-azdls"] }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "deb4a3c8d5277b76d60f43ecaf6d598b0de50873" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "deb4a3c8d5277b76d60f43ecaf6d598b0de50873" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "deb4a3c8d5277b76d60f43ecaf6d598b0de50873" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "6bd8e98fe920def857f80024f5a666c9631e80f4" }
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "deb4a3c8d5277b76d60f43ecaf6d598b0de50873" }
 
 parquet = { version = "58.1", features = ["async"] }
 port_scanner = "0.1.5"


### PR DESCRIPTION
## Summary

- bump all iceberg-rust dependencies from `6bd8e98fe920def857f80024f5a666c9631e80f4` to the latest `dev_rebase_main_20260303` commit, `deb4a3c8d5277b76d60f43ecaf6d598b0de50873`
- pick up per-bucket S3/GCS OpenDAL operator caching from risingwavelabs/iceberg-rust#208
- keep the downstream change limited to `Cargo.toml` and `Cargo.lock`

## Dependency

- branch: https://github.com/risingwavelabs/iceberg-rust/tree/dev_rebase_main_20260303
- upstream PR: https://github.com/risingwavelabs/iceberg-rust/pull/208
- commit: https://github.com/risingwavelabs/iceberg-rust/commit/deb4a3c8d5277b76d60f43ecaf6d598b0de50873

## Validation

- `cargo check --locked --workspace --all-targets --all-features`
- `make check` with the repository-pinned `nightly-2025-10-10` toolchain
- `make unit-test` (134 passed)
- `git diff --check`

The local integration suite currently fails before compaction when the unpinned `apache/iceberg-rest-fixture` returns 404 for namespace creation. The same 5/5 failures reproduce on unmodified `origin/main@200543a`, so they are unrelated to this dependency bump.
