### PR TITLE
chore: bump iceberg-rust for equality-delete metrics pruning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c39309944d2b7f1c81ae2d24c3aa32fd1da66590#c39309944d2b7f1c81ae2d24c3aa32fd1da66590"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=1ec9ed103345825b98546cc756e5d22f5e501d72#1ec9ed103345825b98546cc756e5d22f5e501d72"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c39309944d2b7f1c81ae2d24c3aa32fd1da66590#c39309944d2b7f1c81ae2d24c3aa32fd1da66590"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=1ec9ed103345825b98546cc756e5d22f5e501d72#1ec9ed103345825b98546cc756e5d22f5e501d72"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c39309944d2b7f1c81ae2d24c3aa32fd1da66590#c39309944d2b7f1c81ae2d24c3aa32fd1da66590"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=1ec9ed103345825b98546cc756e5d22f5e501d72#1ec9ed103345825b98546cc756e5d22f5e501d72"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c39309944d2b7f1c81ae2d24c3aa32fd1da66590#c39309944d2b7f1c81ae2d24c3aa32fd1da66590"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=1ec9ed103345825b98546cc756e5d22f5e501d72#1ec9ed103345825b98546cc756e5d22f5e501d72"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=c39309944d2b7f1c81ae2d24c3aa32fd1da66590#c39309944d2b7f1c81ae2d24c3aa32fd1da66590"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=1ec9ed103345825b98546cc756e5d22f5e501d72#1ec9ed103345825b98546cc756e5d22f5e501d72"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ datafusion = "54.1"
 # Local workspace members
 futures = "0.3.17"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1ec9ed103345825b98546cc756e5d22f5e501d72" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1ec9ed103345825b98546cc756e5d22f5e501d72" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1ec9ed103345825b98546cc756e5d22f5e501d72" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1ec9ed103345825b98546cc756e5d22f5e501d72" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "c39309944d2b7f1c81ae2d24c3aa32fd1da66590", features = [
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1ec9ed103345825b98546cc756e5d22f5e501d72" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1ec9ed103345825b98546cc756e5d22f5e501d72", features = [
     "opendal-s3",
 ] }
 


### PR DESCRIPTION
## Summary

- bump all `iceberg-rust` dependencies to `1ec9ed103345825b98546cc756e5d22f5e501d72`
- pick up conservative equality-delete metrics pruning from risingwavelabs/iceberg-rust#213
- keep the downstream change limited to the dependency revs in `Cargo.toml` and `Cargo.lock`

`FilesWithDeletes` planning continues to use the existing scan path; the updated SDK now omits equality deletes whose bounds cannot overlap a data file, so unaffected data files are not selected for rewrite.

## Dependency chain

- upstream PR: https://github.com/risingwavelabs/iceberg-rust/pull/213
- upstream commit: https://github.com/risingwavelabs/iceberg-rust/commit/1ec9ed103345825b98546cc756e5d22f5e501d72
- downstream RisingWave PR: https://github.com/risingwavelabs/risingwave/pull/26768

## Validation

- `RUSTC_WRAPPER= make check`
- `RUSTC_WRAPPER= cargo test -p iceberg-compaction-core test_delete_file_count_filter_strategy`
- `git diff --check`
