### PR TITLE
feat: propagate delete cleanup sequence from planning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=1ec9ed103345825b98546cc756e5d22f5e501d72#1ec9ed103345825b98546cc756e5d22f5e501d72"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=886d69ea90d827af493de8ed4aa52a02b099056f#886d69ea90d827af493de8ed4aa52a02b099056f"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=1ec9ed103345825b98546cc756e5d22f5e501d72#1ec9ed103345825b98546cc756e5d22f5e501d72"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=886d69ea90d827af493de8ed4aa52a02b099056f#886d69ea90d827af493de8ed4aa52a02b099056f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=1ec9ed103345825b98546cc756e5d22f5e501d72#1ec9ed103345825b98546cc756e5d22f5e501d72"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=886d69ea90d827af493de8ed4aa52a02b099056f#886d69ea90d827af493de8ed4aa52a02b099056f"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=1ec9ed103345825b98546cc756e5d22f5e501d72#1ec9ed103345825b98546cc756e5d22f5e501d72"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=886d69ea90d827af493de8ed4aa52a02b099056f#886d69ea90d827af493de8ed4aa52a02b099056f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=1ec9ed103345825b98546cc756e5d22f5e501d72#1ec9ed103345825b98546cc756e5d22f5e501d72"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=886d69ea90d827af493de8ed4aa52a02b099056f#886d69ea90d827af493de8ed4aa52a02b099056f"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=886d69ea90d827af493de8ed4aa52a02b099056f#886d69ea90d827af493de8ed4aa52a02b099056f"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=f57eff74f2bc443722f655c01b1b1991343f00d2#f57eff74f2bc443722f655c01b1b1991343f00d2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=886d69ea90d827af493de8ed4aa52a02b099056f#886d69ea90d827af493de8ed4aa52a02b099056f"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=f57eff74f2bc443722f655c01b1b1991343f00d2#f57eff74f2bc443722f655c01b1b1991343f00d2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=886d69ea90d827af493de8ed4aa52a02b099056f#886d69ea90d827af493de8ed4aa52a02b099056f"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=f57eff74f2bc443722f655c01b1b1991343f00d2#f57eff74f2bc443722f655c01b1b1991343f00d2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=886d69ea90d827af493de8ed4aa52a02b099056f#886d69ea90d827af493de8ed4aa52a02b099056f"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=f57eff74f2bc443722f655c01b1b1991343f00d2#f57eff74f2bc443722f655c01b1b1991343f00d2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=886d69ea90d827af493de8ed4aa52a02b099056f#886d69ea90d827af493de8ed4aa52a02b099056f"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=f57eff74f2bc443722f655c01b1b1991343f00d2#f57eff74f2bc443722f655c01b1b1991343f00d2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=f57eff74f2bc443722f655c01b1b1991343f00d2#f57eff74f2bc443722f655c01b1b1991343f00d2"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5680ac6fc74a2ba8220060edbdf8f271cab9eaa9#5680ac6fc74a2ba8220060edbdf8f271cab9eaa9"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=f57eff74f2bc443722f655c01b1b1991343f00d2#f57eff74f2bc443722f655c01b1b1991343f00d2"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5680ac6fc74a2ba8220060edbdf8f271cab9eaa9#5680ac6fc74a2ba8220060edbdf8f271cab9eaa9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=f57eff74f2bc443722f655c01b1b1991343f00d2#f57eff74f2bc443722f655c01b1b1991343f00d2"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5680ac6fc74a2ba8220060edbdf8f271cab9eaa9#5680ac6fc74a2ba8220060edbdf8f271cab9eaa9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=f57eff74f2bc443722f655c01b1b1991343f00d2#f57eff74f2bc443722f655c01b1b1991343f00d2"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5680ac6fc74a2ba8220060edbdf8f271cab9eaa9#5680ac6fc74a2ba8220060edbdf8f271cab9eaa9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=f57eff74f2bc443722f655c01b1b1991343f00d2#f57eff74f2bc443722f655c01b1b1991343f00d2"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5680ac6fc74a2ba8220060edbdf8f271cab9eaa9#5680ac6fc74a2ba8220060edbdf8f271cab9eaa9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5680ac6fc74a2ba8220060edbdf8f271cab9eaa9#5680ac6fc74a2ba8220060edbdf8f271cab9eaa9"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=26e30f77b1dcc822d886f65fefdf704d6eb77f5e#26e30f77b1dcc822d886f65fefdf704d6eb77f5e"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5680ac6fc74a2ba8220060edbdf8f271cab9eaa9#5680ac6fc74a2ba8220060edbdf8f271cab9eaa9"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=26e30f77b1dcc822d886f65fefdf704d6eb77f5e#26e30f77b1dcc822d886f65fefdf704d6eb77f5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5680ac6fc74a2ba8220060edbdf8f271cab9eaa9#5680ac6fc74a2ba8220060edbdf8f271cab9eaa9"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=26e30f77b1dcc822d886f65fefdf704d6eb77f5e#26e30f77b1dcc822d886f65fefdf704d6eb77f5e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5680ac6fc74a2ba8220060edbdf8f271cab9eaa9#5680ac6fc74a2ba8220060edbdf8f271cab9eaa9"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=26e30f77b1dcc822d886f65fefdf704d6eb77f5e#26e30f77b1dcc822d886f65fefdf704d6eb77f5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5680ac6fc74a2ba8220060edbdf8f271cab9eaa9#5680ac6fc74a2ba8220060edbdf8f271cab9eaa9"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=26e30f77b1dcc822d886f65fefdf704d6eb77f5e#26e30f77b1dcc822d886f65fefdf704d6eb77f5e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ datafusion = "54.1"
 # Local workspace members
 futures = "0.3.17"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "886d69ea90d827af493de8ed4aa52a02b099056f" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "886d69ea90d827af493de8ed4aa52a02b099056f" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "886d69ea90d827af493de8ed4aa52a02b099056f" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "886d69ea90d827af493de8ed4aa52a02b099056f" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "f57eff74f2bc443722f655c01b1b1991343f00d2" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "f57eff74f2bc443722f655c01b1b1991343f00d2" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "f57eff74f2bc443722f655c01b1b1991343f00d2" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "f57eff74f2bc443722f655c01b1b1991343f00d2" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "886d69ea90d827af493de8ed4aa52a02b099056f" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "886d69ea90d827af493de8ed4aa52a02b099056f", features = [
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "f57eff74f2bc443722f655c01b1b1991343f00d2" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "f57eff74f2bc443722f655c01b1b1991343f00d2", features = [
     "opendal-s3",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ datafusion = "54.1"
 # Local workspace members
 futures = "0.3.17"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5680ac6fc74a2ba8220060edbdf8f271cab9eaa9" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5680ac6fc74a2ba8220060edbdf8f271cab9eaa9" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5680ac6fc74a2ba8220060edbdf8f271cab9eaa9" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5680ac6fc74a2ba8220060edbdf8f271cab9eaa9" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "26e30f77b1dcc822d886f65fefdf704d6eb77f5e" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "26e30f77b1dcc822d886f65fefdf704d6eb77f5e" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "26e30f77b1dcc822d886f65fefdf704d6eb77f5e" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "26e30f77b1dcc822d886f65fefdf704d6eb77f5e" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5680ac6fc74a2ba8220060edbdf8f271cab9eaa9" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5680ac6fc74a2ba8220060edbdf8f271cab9eaa9", features = [
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "26e30f77b1dcc822d886f65fefdf704d6eb77f5e" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "26e30f77b1dcc822d886f65fefdf704d6eb77f5e", features = [
     "opendal-s3",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ datafusion = "54.1"
 # Local workspace members
 futures = "0.3.17"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "f57eff74f2bc443722f655c01b1b1991343f00d2" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "f57eff74f2bc443722f655c01b1b1991343f00d2" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "f57eff74f2bc443722f655c01b1b1991343f00d2" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "f57eff74f2bc443722f655c01b1b1991343f00d2" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5680ac6fc74a2ba8220060edbdf8f271cab9eaa9" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5680ac6fc74a2ba8220060edbdf8f271cab9eaa9" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5680ac6fc74a2ba8220060edbdf8f271cab9eaa9" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5680ac6fc74a2ba8220060edbdf8f271cab9eaa9" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "f57eff74f2bc443722f655c01b1b1991343f00d2" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "f57eff74f2bc443722f655c01b1b1991343f00d2", features = [
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5680ac6fc74a2ba8220060edbdf8f271cab9eaa9" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5680ac6fc74a2ba8220060edbdf8f271cab9eaa9", features = [
     "opendal-s3",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ datafusion = "54.1"
 # Local workspace members
 futures = "0.3.17"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1ec9ed103345825b98546cc756e5d22f5e501d72" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1ec9ed103345825b98546cc756e5d22f5e501d72" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1ec9ed103345825b98546cc756e5d22f5e501d72" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1ec9ed103345825b98546cc756e5d22f5e501d72" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "886d69ea90d827af493de8ed4aa52a02b099056f" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "886d69ea90d827af493de8ed4aa52a02b099056f" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "886d69ea90d827af493de8ed4aa52a02b099056f" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "886d69ea90d827af493de8ed4aa52a02b099056f" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1ec9ed103345825b98546cc756e5d22f5e501d72" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "1ec9ed103345825b98546cc756e5d22f5e501d72", features = [
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "886d69ea90d827af493de8ed4aa52a02b099056f" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "886d69ea90d827af493de8ed4aa52a02b099056f", features = [
     "opendal-s3",
 ] }
 

--- a/core/src/compaction/auto.rs
+++ b/core/src/compaction/auto.rs
@@ -140,6 +140,8 @@ impl AutoCompactionPlanner {
         let snapshot_id = snapshot.snapshot_id();
 
         let mut tasks = Some(FileSelector::scan_data_files(table, snapshot_id).await?);
+        let delete_cleanup_min_data_sequence_number =
+            FileSelector::delete_cleanup_min_data_sequence_number(tasks.as_ref().unwrap());
         let total_data_bytes = compute_total_data_bytes(tasks.as_ref().unwrap());
         let stats = Self::compute_stats(
             tasks.as_ref().unwrap(),
@@ -166,6 +168,7 @@ impl AutoCompactionPlanner {
                 snapshot_id,
                 total_data_bytes,
                 AutoPlanReason::Recommended,
+                delete_cleanup_min_data_sequence_number,
             )?;
             if report.plans.is_empty() {
                 Some(report)
@@ -188,6 +191,7 @@ impl AutoCompactionPlanner {
                 snapshot_id,
                 total_data_bytes,
                 AutoPlanReason::Recommended,
+                delete_cleanup_min_data_sequence_number,
             )?)
         } else {
             None
@@ -208,6 +212,7 @@ impl AutoCompactionPlanner {
         snapshot_id: i64,
         total_data_bytes: u64,
         reason: AutoPlanReason,
+        delete_cleanup_min_data_sequence_number: Option<i64>,
     ) -> Result<AutoPlanReport> {
         let selected_strategy = AutoSelectedStrategy::from_planning_config(&planning_config);
         let strategy = PlanStrategy::from(&planning_config);
@@ -216,7 +221,12 @@ impl AutoCompactionPlanner {
 
         let plans: Vec<CompactionPlan> = file_groups
             .into_iter()
-            .map(|fg| CompactionPlan::new(fg, to_branch.to_owned(), snapshot_id))
+            .map(|fg| {
+                CompactionPlan::new(fg, to_branch.to_owned(), snapshot_id)
+                    .with_delete_cleanup_min_data_sequence_number(
+                        delete_cleanup_min_data_sequence_number,
+                    )
+            })
             .filter(|p| p.has_files())
             .collect();
         Ok(Self::report_from_plans(

--- a/core/src/compaction/mod.rs
+++ b/core/src/compaction/mod.rs
@@ -921,11 +921,19 @@ impl CommitManager {
         rewrite_results: Vec<RewriteResult>,
         to_branch: &str,
     ) -> Result<Table> {
+        let delete_cleanup_min_data_sequence_number = rewrite_results
+            .first()
+            .and_then(|result| result.plan.delete_cleanup_min_data_sequence_number);
         let (added_data_files, rewritten_data_files) = self
             .collect_files_from_results(&rewrite_results, to_branch)
             .await?;
-        self.rewrite_files(added_data_files, rewritten_data_files, to_branch)
-            .await
+        self.rewrite_files_with_delete_cleanup_sequence(
+            added_data_files,
+            rewritten_data_files,
+            to_branch,
+            delete_cleanup_min_data_sequence_number,
+        )
+        .await
     }
 
     /// Overwrites files from results: file collection, validation, and commit.
@@ -955,6 +963,22 @@ impl CommitManager {
         added_data_files: Vec<DataFile>,
         rewritten_data_files: Vec<DataFile>,
         to_branch: &str,
+    ) -> Result<Table> {
+        self.rewrite_files_with_delete_cleanup_sequence(
+            added_data_files,
+            rewritten_data_files,
+            to_branch,
+            None,
+        )
+        .await
+    }
+
+    async fn rewrite_files_with_delete_cleanup_sequence(
+        &self,
+        added_data_files: Vec<DataFile>,
+        rewritten_data_files: Vec<DataFile>,
+        to_branch: &str,
+        delete_cleanup_min_data_sequence_number: Option<i64>,
     ) -> Result<Table> {
         let data_files = added_data_files;
         let delete_files = rewritten_data_files;
@@ -986,7 +1010,7 @@ impl CommitManager {
                 let txn = Transaction::new(&table);
 
                 // TODO: support validation of data files and delete files with starting snapshot before applying the rewrite
-                let rewrite_action = if use_starting_sequence_number {
+                let mut rewrite_action = if use_starting_sequence_number {
                     // TODO: avoid retry if the snapshot_id is not found
                     if let Some(snapshot) = table.metadata().snapshot_by_id(starting_snapshot_id) {
                         let mut action = txn
@@ -1020,6 +1044,11 @@ impl CommitManager {
                     }
                     action
                 };
+
+                if let Some(sequence_number) = delete_cleanup_min_data_sequence_number {
+                    rewrite_action = rewrite_action
+                        .set_delete_file_cleanup_min_data_sequence_number(sequence_number);
+                }
 
                 let txn = rewrite_action.apply(txn)?;
                 match txn.commit(catalog.as_ref()).await {
@@ -1235,6 +1264,8 @@ pub struct CompactionPlan {
     pub to_branch: Cow<'static, str>,
     /// Snapshot ID from which files were selected
     pub snapshot_id: i64,
+    /// Minimum data sequence among files with applicable deletes in the planned snapshot.
+    delete_cleanup_min_data_sequence_number: Option<i64>,
 }
 
 impl CompactionPlan {
@@ -1248,7 +1279,16 @@ impl CompactionPlan {
             file_group,
             to_branch: to_branch.into(),
             snapshot_id,
+            delete_cleanup_min_data_sequence_number: None,
         }
+    }
+
+    pub(crate) fn with_delete_cleanup_min_data_sequence_number(
+        mut self,
+        sequence_number: Option<i64>,
+    ) -> Self {
+        self.delete_cleanup_min_data_sequence_number = sequence_number;
+        self
     }
 
     /// Creates an empty plan for testing.
@@ -1257,6 +1297,7 @@ impl CompactionPlan {
             file_group: FileGroup::empty(),
             to_branch: Cow::Borrowed(MAIN_BRANCH),
             snapshot_id: UNASSIGNED_SNAPSHOT_ID,
+            delete_cleanup_min_data_sequence_number: None,
         }
     }
 
@@ -1314,7 +1355,7 @@ impl CompactionPlanner {
     ) -> Result<Vec<CompactionPlan>> {
         if let Some(branch_snapshot) = table.metadata().snapshot_for_ref(to_branch) {
             // Step 1: Group files for compaction (extensible)
-            let file_groups: Vec<FileGroup> = self
+            let (file_groups, delete_cleanup_min_data_sequence_number) = self
                 .group_files_for_compaction(table, branch_snapshot.snapshot_id())
                 .await?;
 
@@ -1327,6 +1368,9 @@ impl CompactionPlanner {
                         file_group,
                         to_branch.to_owned(),
                         branch_snapshot.snapshot_id(),
+                    )
+                    .with_delete_cleanup_min_data_sequence_number(
+                        delete_cleanup_min_data_sequence_number,
                     )
                 })
                 .filter(|plan| plan.has_files())
@@ -1350,11 +1394,14 @@ impl CompactionPlanner {
         &self,
         table: &Table,
         snapshot_id: i64,
-    ) -> Result<Vec<FileGroup>> {
+    ) -> Result<(Vec<FileGroup>, Option<i64>)> {
         use crate::file_selection::PlanStrategy;
 
         let strategy = PlanStrategy::from(&self.config);
-        FileSelector::get_scan_tasks_with_strategy(table, snapshot_id, strategy, &self.config).await
+        let tasks = FileSelector::scan_data_files(table, snapshot_id).await?;
+        let min_sequence = FileSelector::delete_cleanup_min_data_sequence_number(&tasks);
+        let file_groups = FileSelector::group_tasks_with_strategy(tasks, strategy, &self.config)?;
+        Ok((file_groups, min_sequence))
     }
 }
 
@@ -1863,7 +1910,7 @@ mod tests {
             .snapshot_for_ref(MAIN_BRANCH)
             .unwrap();
 
-        let files_to_compact = planner
+        let (files_to_compact, _) = planner
             .group_files_for_compaction(&updated_table, snapshot_before.snapshot_id())
             .await
             .unwrap();

--- a/core/src/file_selection/mod.rs
+++ b/core/src/file_selection/mod.rs
@@ -65,6 +65,11 @@ impl FileSelector {
 
     /// Returns the minimum data sequence among files with applicable deletes.
     ///
+    /// `tasks` must contain every live data-file task from the snapshot's complete,
+    /// unfiltered `plan_files()` result. Each `task.deletes` must conservatively
+    /// include every delete file that may apply; otherwise this threshold could
+    /// retire a delete file that is still needed by an affected data file.
+    ///
     /// Missing or invalid sequence metadata disables the optimization.
     pub(crate) fn delete_cleanup_min_data_sequence_number(tasks: &[FileScanTask]) -> Option<i64> {
         let mut min_sequence = None;

--- a/core/src/file_selection/mod.rs
+++ b/core/src/file_selection/mod.rs
@@ -63,6 +63,20 @@ impl FileSelector {
         Ok(data_files)
     }
 
+    /// Returns the minimum data sequence among files with applicable deletes.
+    ///
+    /// Missing or invalid sequence metadata disables the optimization.
+    pub(crate) fn delete_cleanup_min_data_sequence_number(tasks: &[FileScanTask]) -> Option<i64> {
+        let mut min_sequence = None;
+        for task in tasks.iter().filter(|task| !task.deletes.is_empty()) {
+            let sequence = task
+                .data_sequence_number
+                .filter(|sequence| *sequence >= 0)?;
+            min_sequence = Some(min_sequence.map_or(sequence, |min: i64| min.min(sequence)));
+        }
+        min_sequence
+    }
+
     /// Groups pre-scanned tasks using the given strategy, skipping the scan phase.
     ///
     /// Use this when tasks have already been collected (e.g., for stats calculation)

--- a/core/src/file_selection/strategy.rs
+++ b/core/src/file_selection/strategy.rs
@@ -999,6 +999,7 @@ mod tests {
         delete_types: Vec<iceberg::spec::DataContentType>,
         partition: Option<iceberg::spec::Struct>,
         schema: Option<Arc<iceberg::spec::Schema>>,
+        data_sequence_number: Option<i64>,
     }
 
     impl TestFileBuilder {
@@ -1010,6 +1011,7 @@ mod tests {
                 delete_types: vec![],
                 partition: None,
                 schema: None,
+                data_sequence_number: None,
             }
         }
 
@@ -1036,6 +1038,11 @@ mod tests {
 
         pub fn with_schema(mut self, schema: Arc<iceberg::spec::Schema>) -> Self {
             self.schema = Some(schema);
+            self
+        }
+
+        pub fn with_data_sequence_number(mut self, sequence_number: i64) -> Self {
+            self.data_sequence_number = Some(sequence_number);
             self
         }
 
@@ -1076,7 +1083,7 @@ mod tests {
                 length: self.size,
                 record_count: Some(100),
                 first_row_id: None,
-                data_sequence_number: None,
+                data_sequence_number: self.data_sequence_number,
                 data_file_path: self.path,
                 data_file_format: DataFileFormat::Parquet,
                 schema: self.schema.unwrap_or(get_test_schema()),
@@ -1093,6 +1100,39 @@ mod tests {
                 key_metadata: None,
             }
         }
+    }
+
+    #[test]
+    fn test_delete_cleanup_min_data_sequence_number() {
+        let tasks = vec![
+            TestFileBuilder::new("old-clean.parquet")
+                .with_data_sequence_number(1)
+                .build(),
+            TestFileBuilder::new("newer-affected.parquet")
+                .with_data_sequence_number(10)
+                .with_deletes()
+                .build(),
+            TestFileBuilder::new("oldest-affected.parquet")
+                .with_data_sequence_number(8)
+                .with_deletes()
+                .build(),
+        ];
+        assert_eq!(
+            crate::file_selection::FileSelector::delete_cleanup_min_data_sequence_number(&tasks),
+            Some(8)
+        );
+
+        let missing_sequence = vec![
+            TestFileBuilder::new("unknown.parquet")
+                .with_deletes()
+                .build(),
+        ];
+        assert_eq!(
+            crate::file_selection::FileSelector::delete_cleanup_min_data_sequence_number(
+                &missing_sequence
+            ),
+            None
+        );
     }
 
     /// Helper functions for common test scenarios


### PR DESCRIPTION
## Summary

- bump `iceberg-rust` dependencies to `26e30f77b1dcc822d886f65fefdf704d6eb77f5e`
- retain conservative read-side position-delete file-path bounds pruning from risingwavelabs/iceberg-rust#214
- compute the minimum data sequence among scan tasks with applicable deletes, before strategy filtering
- carry that optional value through every planned rewrite and use it for SDK delete-file cleanup at commit time
- preserve the original global-minimum cleanup when the planner has no usable delete-related data sequence

The added planning work is one linear pass over the already planned data-file tasks. It does not add a data-file-by-delete-file scan. Missing or invalid data sequence metadata disables the override and falls back to the existing SDK behavior.

## Dependency chain

- position-delete bounds: https://github.com/risingwavelabs/iceberg-rust/pull/214
- delete-cleanup override: https://github.com/risingwavelabs/iceberg-rust/pull/215
- pinned SDK commit: https://github.com/risingwavelabs/iceberg-rust/commit/26e30f77b1dcc822d886f65fefdf704d6eb77f5e
- downstream RisingWave PR: https://github.com/risingwavelabs/risingwave/pull/26768

## Validation

- `cargo test --locked -p iceberg-compaction-core file_selection::strategy` (36 passed)
- `cargo test --locked -p iceberg-compaction-core auto --lib` (10 passed)
- `cargo clippy --locked -p iceberg-compaction-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
