### PR TITLE
chore: update delete cleanup SDK rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=26e30f77b1dcc822d886f65fefdf704d6eb77f5e#26e30f77b1dcc822d886f65fefdf704d6eb77f5e"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7ab827e238156e11cde476abc156f3023ad4b83d#7ab827e238156e11cde476abc156f3023ad4b83d"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=26e30f77b1dcc822d886f65fefdf704d6eb77f5e#26e30f77b1dcc822d886f65fefdf704d6eb77f5e"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7ab827e238156e11cde476abc156f3023ad4b83d#7ab827e238156e11cde476abc156f3023ad4b83d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=26e30f77b1dcc822d886f65fefdf704d6eb77f5e#26e30f77b1dcc822d886f65fefdf704d6eb77f5e"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7ab827e238156e11cde476abc156f3023ad4b83d#7ab827e238156e11cde476abc156f3023ad4b83d"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=26e30f77b1dcc822d886f65fefdf704d6eb77f5e#26e30f77b1dcc822d886f65fefdf704d6eb77f5e"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7ab827e238156e11cde476abc156f3023ad4b83d#7ab827e238156e11cde476abc156f3023ad4b83d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=26e30f77b1dcc822d886f65fefdf704d6eb77f5e#26e30f77b1dcc822d886f65fefdf704d6eb77f5e"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7ab827e238156e11cde476abc156f3023ad4b83d#7ab827e238156e11cde476abc156f3023ad4b83d"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ datafusion = "54.1"
 # Local workspace members
 futures = "0.3.17"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "26e30f77b1dcc822d886f65fefdf704d6eb77f5e" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "26e30f77b1dcc822d886f65fefdf704d6eb77f5e" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "26e30f77b1dcc822d886f65fefdf704d6eb77f5e" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "26e30f77b1dcc822d886f65fefdf704d6eb77f5e" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7ab827e238156e11cde476abc156f3023ad4b83d" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7ab827e238156e11cde476abc156f3023ad4b83d" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7ab827e238156e11cde476abc156f3023ad4b83d" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7ab827e238156e11cde476abc156f3023ad4b83d" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "26e30f77b1dcc822d886f65fefdf704d6eb77f5e" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "26e30f77b1dcc822d886f65fefdf704d6eb77f5e", features = [
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7ab827e238156e11cde476abc156f3023ad4b83d" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7ab827e238156e11cde476abc156f3023ad4b83d", features = [
     "opendal-s3",
 ] }
 


### PR DESCRIPTION
## Summary

- replace the temporary iceberg-rust PR head revision with the squash-merge commit from risingwavelabs/iceberg-rust#215
- keep `Cargo.lock` aligned with the exact revision without updating any dependency versions

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo test --locked -p iceberg-compaction-core test_delete_cleanup_min_data_sequence_number --lib`
- `make check`
- `git diff --check`

Depends on risingwavelabs/iceberg-rust#215.
