### PR TITLE
chore: update live delete cleanup SDK rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7ab827e238156e11cde476abc156f3023ad4b83d#7ab827e238156e11cde476abc156f3023ad4b83d"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5020f93609cd61cb993682eb65852e4f565613e3#5020f93609cd61cb993682eb65852e4f565613e3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7ab827e238156e11cde476abc156f3023ad4b83d#7ab827e238156e11cde476abc156f3023ad4b83d"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5020f93609cd61cb993682eb65852e4f565613e3#5020f93609cd61cb993682eb65852e4f565613e3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7ab827e238156e11cde476abc156f3023ad4b83d#7ab827e238156e11cde476abc156f3023ad4b83d"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5020f93609cd61cb993682eb65852e4f565613e3#5020f93609cd61cb993682eb65852e4f565613e3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7ab827e238156e11cde476abc156f3023ad4b83d#7ab827e238156e11cde476abc156f3023ad4b83d"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5020f93609cd61cb993682eb65852e4f565613e3#5020f93609cd61cb993682eb65852e4f565613e3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=7ab827e238156e11cde476abc156f3023ad4b83d#7ab827e238156e11cde476abc156f3023ad4b83d"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5020f93609cd61cb993682eb65852e4f565613e3#5020f93609cd61cb993682eb65852e4f565613e3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ datafusion = "54.1"
 # Local workspace members
 futures = "0.3.17"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7ab827e238156e11cde476abc156f3023ad4b83d" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7ab827e238156e11cde476abc156f3023ad4b83d" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7ab827e238156e11cde476abc156f3023ad4b83d" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7ab827e238156e11cde476abc156f3023ad4b83d" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5020f93609cd61cb993682eb65852e4f565613e3" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5020f93609cd61cb993682eb65852e4f565613e3" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5020f93609cd61cb993682eb65852e4f565613e3" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5020f93609cd61cb993682eb65852e4f565613e3" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7ab827e238156e11cde476abc156f3023ad4b83d" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "7ab827e238156e11cde476abc156f3023ad4b83d", features = [
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5020f93609cd61cb993682eb65852e4f565613e3" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5020f93609cd61cb993682eb65852e4f565613e3", features = [
     "opendal-s3",
 ] }
 


### PR DESCRIPTION
## What changed

Pin Iceberg Rust to the merge commit of risingwavelabs/iceberg-rust#216 so delete cleanup keeps both the planning-derived bound and the minimum sequence of data files that remain live after the commit.

Dependency:

- https://github.com/risingwavelabs/iceberg-rust/pull/216
- Iceberg Rust rev: `5020f93609cd61cb993682eb65852e4f565613e3`

## Validation

- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
