### PR TITLE
chore: bump iceberg-rust to 2768ccf8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5020f93609cd61cb993682eb65852e4f565613e3#5020f93609cd61cb993682eb65852e4f565613e3"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5020f93609cd61cb993682eb65852e4f565613e3#5020f93609cd61cb993682eb65852e4f565613e3"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5020f93609cd61cb993682eb65852e4f565613e3#5020f93609cd61cb993682eb65852e4f565613e3"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5020f93609cd61cb993682eb65852e4f565613e3#5020f93609cd61cb993682eb65852e4f565613e3"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=5020f93609cd61cb993682eb65852e4f565613e3#5020f93609cd61cb993682eb65852e4f565613e3"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ datafusion = "54.1"
 # Local workspace members
 futures = "0.3.17"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5020f93609cd61cb993682eb65852e4f565613e3" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5020f93609cd61cb993682eb65852e4f565613e3" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5020f93609cd61cb993682eb65852e4f565613e3" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5020f93609cd61cb993682eb65852e4f565613e3" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5020f93609cd61cb993682eb65852e4f565613e3" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "5020f93609cd61cb993682eb65852e4f565613e3", features = [
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8", features = [
     "opendal-s3",
 ] }
 


### PR DESCRIPTION
## What changed

- pin all iceberg-rust workspace dependencies to the latest `dev_rebase_main_20260807` head at `2768ccf8b1847a14162337d7ef7a76935881fbc8`
- include the five fixes since `5020f936`, covering Variant projection/writes, partial-overwrite summary rollup, void partition validation, and pre-epoch/default timestamp handling
- update only the matching git source revisions in `Cargo.lock`; the dependency graph is unchanged

Dependency:

- https://github.com/risingwavelabs/iceberg-rust/tree/dev_rebase_main_20260807
- https://github.com/risingwavelabs/iceberg-rust/compare/5020f93609cd61cb993682eb65852e4f565613e3...2768ccf8b1847a14162337d7ef7a76935881fbc8

## Validation

- `cargo check --locked --workspace --all-targets`
- `make check`
- `make unit-test` (127 passed)
- `git diff --check`
