### PR TITLE
feat: share one memory pool across concurrent rewrite plans

### DIFF
--- a/core/src/compaction/validator.rs
+++ b/core/src/compaction/validator.rs
@@ -113,6 +113,7 @@ impl CompactionValidator {
             validator_config,
             executor_parallelism,
             table.file_io().clone(),
+            None,
         )?;
 
         Ok(Self {

--- a/core/src/executor/datafusion/datafusion_processor.rs
+++ b/core/src/executor/datafusion/datafusion_processor.rs
@@ -61,6 +61,7 @@ impl DatafusionProcessor {
         execution_config: Arc<CompactionExecutionConfig>,
         executor_parallelism: usize,
         file_io: FileIO,
+        shared_runtime: Option<Arc<RuntimeEnv>>,
     ) -> Result<Self> {
         let session_config = SessionConfig::new()
             .with_target_partitions(executor_parallelism)
@@ -70,24 +71,33 @@ impl DatafusionProcessor {
                 execution_config.enable_normalized_column_identifiers,
             );
 
-        // When a memory budget is configured, run DataFusion with a bounded
-        // `FairSpillPool` and an OS-backed `DiskManager` so blocking operators
-        // (notably `SortExec` for sorted-table compaction) spill to disk once
-        // they exceed the budget, instead of buffering all decoded Arrow data
-        // in memory and OOM-killing the process. With no budget we keep the
-        // previous behavior: an unbounded pool and no spilling.
-        let ctx = match execution_config.max_memory_bytes {
-            Some(max_memory_bytes) if max_memory_bytes > 0 => {
-                let runtime_env = build_spilling_runtime_env(
-                    max_memory_bytes,
-                    execution_config.spill_dir.as_deref(),
-                )?;
-                Arc::new(SessionContext::new_with_config_rt(
-                    session_config,
-                    runtime_env,
-                ))
-            }
-            _ => Arc::new(SessionContext::new_with_config(session_config)),
+        // Memory-pool selection, in priority order:
+        // 1. `shared_runtime` (built once and shared across all concurrent
+        //    `rewrite_files` calls on a single executor) — makes `max_memory_bytes`
+        //    a *pod-wide* ceiling instead of a per-plan one. See
+        //    `DataFusionExecutor::shared_runtime_env`.
+        // 2. else a per-call bounded `FairSpillPool` + OS `DiskManager` when a
+        //    budget is configured, so blocking operators (notably `SortExec`) spill
+        //    to disk once they exceed the budget instead of OOM-killing the process.
+        // 3. else the previous behavior: an unbounded pool and no spilling.
+        let ctx = match shared_runtime {
+            Some(runtime_env) => Arc::new(SessionContext::new_with_config_rt(
+                session_config,
+                runtime_env,
+            )),
+            None => match execution_config.max_memory_bytes {
+                Some(max_memory_bytes) if max_memory_bytes > 0 => {
+                    let runtime_env = build_spilling_runtime_env(
+                        max_memory_bytes,
+                        execution_config.spill_dir.as_deref(),
+                    )?;
+                    Arc::new(SessionContext::new_with_config_rt(
+                        session_config,
+                        runtime_env,
+                    ))
+                }
+                _ => Arc::new(SessionContext::new_with_config(session_config)),
+            },
         };
 
         let table_register = DatafusionTableRegister::new(
@@ -225,7 +235,7 @@ impl DatafusionProcessor {
 /// `SortExec`) spill to disk once they exceed the pool instead of buffering
 /// unbounded in memory. Spill files go to `spill_dir` when provided, otherwise
 /// the OS temp directory.
-fn build_spilling_runtime_env(
+pub(crate) fn build_spilling_runtime_env(
     max_memory_bytes: usize,
     spill_dir: Option<&std::path::Path>,
 ) -> Result<Arc<RuntimeEnv>> {
@@ -988,7 +998,7 @@ mod tests {
                 .build()
                 .unwrap(),
         );
-        assert!(DatafusionProcessor::new(bounded, 1, file_io.clone()).is_ok());
+        assert!(DatafusionProcessor::new(bounded, 1, file_io.clone(), None).is_ok());
 
         // A configured spill directory is honored by the disk manager.
         let bounded_with_spill_dir = Arc::new(
@@ -998,12 +1008,12 @@ mod tests {
                 .build()
                 .unwrap(),
         );
-        assert!(DatafusionProcessor::new(bounded_with_spill_dir, 1, file_io.clone()).is_ok());
+        assert!(DatafusionProcessor::new(bounded_with_spill_dir, 1, file_io.clone(), None).is_ok());
 
         let unbounded = Arc::new(CompactionExecutionConfigBuilder::default().build().unwrap());
         assert!(unbounded.max_memory_bytes.is_none());
         assert!(unbounded.spill_dir.is_none());
-        assert!(DatafusionProcessor::new(unbounded, 1, file_io).is_ok());
+        assert!(DatafusionProcessor::new(unbounded, 1, file_io, None).is_ok());
     }
 
     /// Validates the bounded runtime built by `build_spilling_runtime_env`

--- a/core/src/executor/datafusion/mod.rs
+++ b/core/src/executor/datafusion/mod.rs
@@ -14,10 +14,11 @@
 * limitations under the License.
 */
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use async_trait::async_trait;
+use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion_processor::{DataFusionTaskContext, DatafusionProcessor};
 use futures::StreamExt;
 use futures::future::try_join_all;
@@ -43,8 +44,58 @@ use super::{RewriteFilesRequest, RewriteFilesResponse};
 pub mod file_scan_task_table_provider;
 pub mod iceberg_file_task_scan;
 
-#[derive(Debug, Default)]
-pub struct DataFusionExecutor {}
+#[derive(Default)]
+pub struct DataFusionExecutor {
+    /// Runtime (bounded `FairSpillPool` + `DiskManager`) built once and shared
+    /// across every `rewrite_files` call on this executor. igloo runs all the
+    /// concurrent plans of one invocation through a single `Compaction`, which
+    /// holds a single `DataFusionExecutor`, so caching the runtime here makes
+    /// `max_memory_bytes` a *pod-wide* ceiling instead of a per-plan one:
+    /// two concurrent unsorted plans would otherwise hold two independent
+    /// `max_memory_bytes` pools and blow the pod's memory limit (F6 OOM).
+    ///
+    /// Lazily initialized from the first request whose `execution_config` sets a
+    /// budget; all plans in an invocation share the same config, so the first
+    /// config governs the shared pool for that invocation. `None` (unbudgeted)
+    /// requests keep the previous per-call, unbounded behavior.
+    shared_runtime: Mutex<Option<Arc<RuntimeEnv>>>,
+}
+
+impl std::fmt::Debug for DataFusionExecutor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DataFusionExecutor").finish_non_exhaustive()
+    }
+}
+
+impl DataFusionExecutor {
+    /// Returns the shared bounded runtime for this executor, building it once on
+    /// first use, or `None` when no memory budget is configured (unbounded,
+    /// per-call behavior preserved).
+    ///
+    /// Sync and holds the lock only to read/populate the cache — the guard is
+    /// dropped before the caller `.await`s, so it never crosses an await point.
+    fn shared_runtime_env(
+        &self,
+        execution_config: &CompactionExecutionConfig,
+    ) -> Result<Option<Arc<RuntimeEnv>>> {
+        let Some(max_memory_bytes) = execution_config.max_memory_bytes.filter(|n| *n > 0) else {
+            return Ok(None);
+        };
+
+        let mut guard = self.shared_runtime.lock().map_err(|e| {
+            CompactionError::Unexpected(format!("shared runtime lock poisoned: {e}"))
+        })?;
+        if let Some(runtime_env) = guard.as_ref() {
+            return Ok(Some(runtime_env.clone()));
+        }
+        let runtime_env = datafusion_processor::build_spilling_runtime_env(
+            max_memory_bytes,
+            execution_config.spill_dir.as_deref(),
+        )?;
+        *guard = Some(runtime_env.clone());
+        Ok(Some(runtime_env))
+    }
+}
 
 #[async_trait]
 impl CompactionExecutor for DataFusionExecutor {
@@ -74,10 +125,12 @@ impl CompactionExecutor for DataFusionExecutor {
             .with_input_data_files(file_group)
             .with_sort_order(sort_order.clone())
             .build()?;
+        let shared_runtime = self.shared_runtime_env(&execution_config)?;
         let (batches, input_schema) = DatafusionProcessor::new(
             execution_config.clone(),
             executor_parallelism,
             file_io.clone(),
+            shared_runtime,
         )?
         .execute(datafusion_task_ctx, output_parallelism)
         .await?;

--- a/core/src/executor/datafusion/mod.rs
+++ b/core/src/executor/datafusion/mod.rs
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
 
 use async_trait::async_trait;
@@ -54,11 +54,24 @@ pub struct DataFusionExecutor {
     /// two concurrent unsorted plans would otherwise hold two independent
     /// `max_memory_bytes` pools and blow the pod's memory limit (F6 OOM).
     ///
-    /// Lazily initialized from the first request whose `execution_config` sets a
-    /// budget; all plans in an invocation share the same config, so the first
-    /// config governs the shared pool for that invocation. `None` (unbudgeted)
-    /// requests keep the previous per-call, unbounded behavior.
-    shared_runtime: Mutex<Option<Arc<RuntimeEnv>>>,
+    /// `OnceLock` so every call after the first successful build is a lock-free
+    /// read. Lazily initialized from the first request whose `execution_config`
+    /// sets a budget; all plans in an invocation share the same config, so the
+    /// first config governs the shared pool for that invocation. `None`
+    /// (unbudgeted) requests keep the previous per-call, unbounded behavior.
+    ///
+    /// Only the success case is cached here: `build_spilling_runtime_env` is
+    /// fallible (e.g. it can fail to create `spill_dir`), and `OnceLock`'s
+    /// initializer must be infallible, so an `Err` is never stored — it's
+    /// returned to that caller and retried on the next call, same as before
+    /// this was split out of the `build_lock`-guarded slow path below.
+    shared_runtime: OnceLock<Arc<RuntimeEnv>>,
+    /// Serializes concurrent first-time builds so only one `RuntimeEnv` is ever
+    /// constructed even when multiple plans race on the very first call —
+    /// otherwise two racing builds could each pass the `shared_runtime.get()`
+    /// check, transiently defeating the single-pool guarantee this cache exists
+    /// for. Held only across the synchronous build, never across an `.await`.
+    build_lock: Mutex<()>,
 }
 
 impl std::fmt::Debug for DataFusionExecutor {
@@ -72,8 +85,9 @@ impl DataFusionExecutor {
     /// first use, or `None` when no memory budget is configured (unbounded,
     /// per-call behavior preserved).
     ///
-    /// Sync and holds the lock only to read/populate the cache — the guard is
-    /// dropped before the caller `.await`s, so it never crosses an await point.
+    /// Sync; the fast path (already built) never locks. The slow path (first
+    /// build) briefly holds `build_lock`, dropped before the caller `.await`s,
+    /// so it never crosses an await point.
     fn shared_runtime_env(
         &self,
         execution_config: &CompactionExecutionConfig,
@@ -82,17 +96,24 @@ impl DataFusionExecutor {
             return Ok(None);
         };
 
-        let mut guard = self.shared_runtime.lock().map_err(|e| {
-            CompactionError::Unexpected(format!("shared runtime lock poisoned: {e}"))
+        if let Some(runtime_env) = self.shared_runtime.get() {
+            return Ok(Some(runtime_env.clone()));
+        }
+
+        let _guard = self.build_lock.lock().map_err(|e| {
+            CompactionError::Unexpected(format!("shared runtime build lock poisoned: {e}"))
         })?;
-        if let Some(runtime_env) = guard.as_ref() {
+        // Someone else may have finished building while we waited for the lock.
+        if let Some(runtime_env) = self.shared_runtime.get() {
             return Ok(Some(runtime_env.clone()));
         }
         let runtime_env = datafusion_processor::build_spilling_runtime_env(
             max_memory_bytes,
             execution_config.spill_dir.as_deref(),
         )?;
-        *guard = Some(runtime_env.clone());
+        // Can only fail if another thread set it between our check and here,
+        // which `build_lock` rules out.
+        let _ = self.shared_runtime.set(runtime_env.clone());
         Ok(Some(runtime_env))
     }
 }


### PR DESCRIPTION
## Problem

`max_memory_bytes` builds a fresh `FairSpillPool` inside every
`DatafusionProcessor::new` — i.e. **one pool per plan execution**. When a caller
runs plans concurrently (e.g. `Compaction::compact` drives
`rewrite_plan`/`rewrite_files` through `buffer_unordered(max_concurrent_compaction_plans)`),
each in-flight plan holds an **independent** pool. So the effective memory
ceiling is `max_concurrent_compaction_plans × max_memory_bytes`, not
`max_memory_bytes`.

Concretely, two concurrent plans against a 10 GiB budget can use 20 GiB. Because
the two pools have no knowledge of each other, aggregate decode grows past the
process/container limit and the process is OOM-killed *before* either pool can
fail fast with `ResourcesExhausted`. Sorted-table compaction avoids this only
because callers typically pin its concurrency to 1 (one live pool).

## Fix

Memoize a single `RuntimeEnv`/`FairSpillPool` on `DataFusionExecutor`, built
once (lazily) from the first budgeted request and shared by every
`rewrite_files` call on that executor. All concurrent plans' decode reservations
now charge the **same** pool, so `max_memory_bytes` is honored as an
executor-wide (hence, for a single-executor invocation, process-wide) ceiling
regardless of `max_concurrent_compaction_plans`, and an over-budget decode
returns a retriable `ResourcesExhausted` instead of OOM-killing the process.

- `DatafusionProcessor::new` gains an `Option<Arc<RuntimeEnv>>` parameter. When
  `Some`, it uses the shared runtime; when `None`, it keeps the previous
  per-call behavior (build a per-call pool from `max_memory_bytes`, or unbounded
  when no budget is set).
- `DataFusionExecutor` caches the shared runtime in a
  `Mutex<Option<Arc<RuntimeEnv>>>` and passes it into `DatafusionProcessor::new`
  from `rewrite_files`. The lock is only held to read/populate the cache and is
  dropped before any `.await`, so it never crosses an await point.
- `build_spilling_runtime_env` is made `pub(crate)` so the executor can build the
  shared runtime once.

## Backwards compatibility

`None` (validator, tests, unbudgeted configs) is byte-for-byte the previous
behavior. Single-plan / concurrency-1 callers are unaffected (the "shared" pool
is just the one pool). Only concurrent budgeted execution changes: the budget is
now a real aggregate ceiling instead of a per-plan one.

## Testing

- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test -p iceberg-compaction-core` — full suite passes, including
  `test_new_with_memory_budget_builds_spilling_context` and
  `test_bounded_runtime_spills_large_sort`.