### PR TITLE
fix: scale output parallelism by partition fan-out

### DIFF
--- a/core/src/compaction/mod.rs
+++ b/core/src/compaction/mod.rs
@@ -30,7 +30,7 @@ use mixtrics::registry::noop::NoopMetricsRegistry;
 
 use crate::common::{CompactionMetricsRecorder, Metrics};
 use crate::compaction::validator::CompactionValidator;
-use crate::config::{CompactionExecutionConfig, CompactionPlanningConfig};
+use crate::config::{CompactionExecutionConfig, CompactionPlanningConfig, FileGroupScope};
 use crate::executor::{
     ExecutorType, RewriteFilesRequest, RewriteFilesResponse, RewriteFilesStat, TableSortOrder,
     create_compaction_executor,
@@ -41,6 +41,7 @@ use crate::{CompactionConfig, CompactionError, CompactionExecutor, Result};
 mod validator;
 
 const UNASSIGNED_SNAPSHOT_ID: i64 = -1;
+const PARTITIONED_TABLE_OUTPUT_PARALLELISM_DIVISOR: usize = 8;
 
 /// Validates that all rewrite results target the same snapshot and branch.
 ///
@@ -1394,7 +1395,21 @@ impl CompactionPlanner {
         let strategy = PlanStrategy::from(&self.config);
         let tasks = FileSelector::scan_data_files(table, snapshot_id).await?;
         let min_sequence = FileSelector::delete_cleanup_min_data_sequence_number(&tasks);
-        let file_groups = FileSelector::group_tasks_with_strategy(tasks, strategy, &self.config)?;
+        let mut file_groups =
+            FileSelector::group_tasks_with_strategy(tasks, strategy, &self.config)?;
+
+        if self.config.file_group_scope() == FileGroupScope::Table
+            && !table.metadata().default_partition_spec().is_unpartitioned()
+        {
+            // Each output stream owns a partition-aware writer. A table-scoped group can therefore
+            // fan out to multiple active partition writers per stream.
+            for file_group in &mut file_groups {
+                file_group.output_parallelism = (file_group.output_parallelism
+                    / PARTITIONED_TABLE_OUTPUT_PARALLELISM_DIVISOR)
+                    .max(1);
+            }
+        }
+
         Ok((file_groups, min_sequence))
     }
 }

--- a/core/src/compaction/mod.rs
+++ b/core/src/compaction/mod.rs
@@ -30,7 +30,7 @@ use mixtrics::registry::noop::NoopMetricsRegistry;
 
 use crate::common::{CompactionMetricsRecorder, Metrics};
 use crate::compaction::validator::CompactionValidator;
-use crate::config::{CompactionExecutionConfig, CompactionPlanningConfig, FileGroupScope};
+use crate::config::{CompactionExecutionConfig, CompactionPlanningConfig};
 use crate::executor::{
     ExecutorType, RewriteFilesRequest, RewriteFilesResponse, RewriteFilesStat, TableSortOrder,
     create_compaction_executor,
@@ -41,7 +41,6 @@ use crate::{CompactionConfig, CompactionError, CompactionExecutor, Result};
 mod validator;
 
 const UNASSIGNED_SNAPSHOT_ID: i64 = -1;
-const PARTITIONED_TABLE_OUTPUT_PARALLELISM_DIVISOR: usize = 8;
 
 /// Validates that all rewrite results target the same snapshot and branch.
 ///
@@ -1395,21 +1394,7 @@ impl CompactionPlanner {
         let strategy = PlanStrategy::from(&self.config);
         let tasks = FileSelector::scan_data_files(table, snapshot_id).await?;
         let min_sequence = FileSelector::delete_cleanup_min_data_sequence_number(&tasks);
-        let mut file_groups =
-            FileSelector::group_tasks_with_strategy(tasks, strategy, &self.config)?;
-
-        if self.config.file_group_scope() == FileGroupScope::Table
-            && !table.metadata().default_partition_spec().is_unpartitioned()
-        {
-            // Each output stream owns a partition-aware writer. A table-scoped group can therefore
-            // fan out to multiple active partition writers per stream.
-            for file_group in &mut file_groups {
-                file_group.output_parallelism = (file_group.output_parallelism
-                    / PARTITIONED_TABLE_OUTPUT_PARALLELISM_DIVISOR)
-                    .max(1);
-            }
-        }
-
+        let file_groups = FileSelector::group_tasks_with_strategy(tasks, strategy, &self.config)?;
         Ok((file_groups, min_sequence))
     }
 }

--- a/core/src/compaction/tests/file_group_scope.rs
+++ b/core/src/compaction/tests/file_group_scope.rs
@@ -26,11 +26,13 @@ use iceberg::table::Table;
 use iceberg::{Catalog, CatalogBuilder, NamespaceIdent, TableCreation, TableIdent};
 use tempfile::TempDir;
 
-use super::{TestEnv, append_and_commit, create_namespace, simple_table_schema};
+use super::{TestEnv, append_and_commit, create_namespace, create_test_env, simple_table_schema};
 use crate::compaction::CompactionPlanner;
 use crate::config::{
     CompactionPlanningConfig, FileGroupScope, FullCompactionConfigBuilder, GroupingStrategy,
 };
+
+const TEST_FILE_SIZE_BYTES: u64 = 8 * 1024 * 1024 * 1024;
 
 #[tokio::test]
 async fn test_plan_compaction_with_table_file_group_scope() {
@@ -54,7 +56,28 @@ async fn test_plan_compaction_with_table_file_group_scope() {
     assert_eq!(partition_scoped_plans.len(), 3);
     assert_eq!(table_scoped_plans.len(), 1);
     assert_eq!(table_scoped_plans[0].file_count(), 5);
+    let mut partition_scoped_output_parallelism = partition_scoped_plans
+        .iter()
+        .map(|plan| plan.recommended_output_parallelism())
+        .collect::<Vec<_>>();
+    partition_scoped_output_parallelism.sort_unstable();
+    assert_eq!(partition_scoped_output_parallelism, vec![8, 16, 16]);
+    assert_eq!(table_scoped_plans[0].recommended_output_parallelism(), 4);
     assert_eq!(table_scoped_plans[0].to_branch, MAIN_BRANCH);
+
+    let unpartitioned_env = create_test_env().await;
+    let unpartitioned_table = append_and_commit(
+        &unpartitioned_env.table,
+        unpartitioned_env.catalog.as_ref(),
+        unpartitioned_data_files(&unpartitioned_env.table),
+    )
+    .await;
+    let unpartitioned_plans = planner(FileGroupScope::Table)
+        .plan_compaction(&unpartitioned_table)
+        .await
+        .unwrap();
+    assert_eq!(unpartitioned_plans.len(), 1);
+    assert_eq!(unpartitioned_plans[0].recommended_output_parallelism(), 32);
 }
 
 fn planner(file_group_scope: FileGroupScope) -> CompactionPlanner {
@@ -62,6 +85,8 @@ fn planner(file_group_scope: FileGroupScope) -> CompactionPlanner {
         FullCompactionConfigBuilder::default()
             .grouping_strategy(GroupingStrategy::Single)
             .file_group_scope(file_group_scope)
+            .max_output_parallelism(32_usize)
+            .enable_heuristic_output_parallelism(false)
             .build()
             .unwrap(),
     ))
@@ -121,7 +146,8 @@ async fn create_partitioned_table<C: Catalog>(catalog: &C, table_ident: &TableId
 
 fn partitioned_data_files(table: &Table) -> Vec<DataFile> {
     let spec_id = table.metadata().default_partition_spec_id();
-    let data_file = |path, partition_id| data_file_with_partition(path, partition_id, spec_id);
+    let data_file =
+        |path, partition_id| data_file_with_partition(path, partition_value(partition_id), spec_id);
 
     vec![
         data_file("file:///test/p0_file1.parquet", 0),
@@ -132,14 +158,27 @@ fn partitioned_data_files(table: &Table) -> Vec<DataFile> {
     ]
 }
 
-fn data_file_with_partition(path: &str, partition_id: i32, partition_spec_id: i32) -> DataFile {
+fn unpartitioned_data_files(table: &Table) -> Vec<DataFile> {
+    let spec_id = table.metadata().default_partition_spec_id();
+    (0..5)
+        .map(|index| {
+            data_file_with_partition(
+                &format!("file:///test/unpartitioned_file{index}.parquet"),
+                Struct::empty(),
+                spec_id,
+            )
+        })
+        .collect()
+}
+
+fn data_file_with_partition(path: &str, partition: Struct, partition_spec_id: i32) -> DataFile {
     DataFileBuilder::default()
         .content(DataContentType::Data)
         .file_format(DataFileFormat::Parquet)
         .file_path(path.to_owned())
-        .file_size_in_bytes(1024)
+        .file_size_in_bytes(TEST_FILE_SIZE_BYTES)
         .record_count(10)
-        .partition(partition_value(partition_id))
+        .partition(partition)
         .partition_spec_id(partition_spec_id)
         .build()
         .unwrap()

--- a/core/src/compaction/tests/file_group_scope.rs
+++ b/core/src/compaction/tests/file_group_scope.rs
@@ -62,7 +62,7 @@ async fn test_plan_compaction_with_table_file_group_scope() {
         .collect::<Vec<_>>();
     partition_scoped_output_parallelism.sort_unstable();
     assert_eq!(partition_scoped_output_parallelism, vec![8, 16, 16]);
-    assert_eq!(table_scoped_plans[0].recommended_output_parallelism(), 4);
+    assert_eq!(table_scoped_plans[0].recommended_output_parallelism(), 10);
     assert_eq!(table_scoped_plans[0].to_branch, MAIN_BRANCH);
 
     let unpartitioned_env = create_test_env().await;

--- a/core/src/file_selection/strategy.rs
+++ b/core/src/file_selection/strategy.rs
@@ -24,7 +24,7 @@
 //!
 //! Parallelism is calculated per group based on file size and count constraints.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use iceberg::scan::FileScanTask;
 
@@ -201,6 +201,21 @@ impl FileGroup {
         // Apply output parallelism heuristic if enabled
         let output_parallelism =
             Self::apply_output_parallelism_heuristic(files_to_compact, config, output_parallelism);
+
+        // Each output stream owns a partition-aware writer, so a group spanning multiple
+        // partitions can fan out to one active writer per distinct partition and stream.
+        let distinct_partition_count = files_to_compact
+            .data_files
+            .iter()
+            .map(|file| {
+                file.partition
+                    .clone()
+                    .unwrap_or_else(iceberg::spec::Struct::empty)
+            })
+            .collect::<HashSet<_>>()
+            .len()
+            .max(1);
+        let output_parallelism = (output_parallelism / distinct_partition_count).max(1);
 
         // Calculate input split size using Iceberg's inputSplitSize algorithm
         let split_size =


### PR DESCRIPTION
A file group can span multiple Iceberg partitions, while each output stream owns a partition-aware writer. The stream parallelism can therefore multiply the number of active output writers by the group’s actual partition fan-out.

Scale each group’s already-computed output parallelism by its distinct partition count, with a minimum of 1. Single-partition groups, including partition-scoped and unpartitioned groups, keep their existing parallelism.