### PR TITLE
feat: route each partition to a single output stream via partition-value hash repartitioning

### DIFF
--- a/core/src/executor/datafusion/datafusion_processor.rs
+++ b/core/src/executor/datafusion/datafusion_processor.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use datafusion::arrow::compute::SortOptions;
@@ -179,7 +178,7 @@ impl DatafusionProcessor {
         // Decide the output distribution before table registration consumes
         // the data file scan tasks.
         let output_partitioning =
-            build_output_partitioning(&datafusion_task_ctx, &input_schema, output_parallelism);
+            build_output_partitioning(&datafusion_task_ctx, &input_schema, output_parallelism)?;
         self.register_tables(datafusion_task_ctx)?;
 
         let df = self.ctx.sql(&exec_sql).await?;
@@ -190,18 +189,7 @@ impl DatafusionProcessor {
         // `RepartitionExec` (the scan's own partitioning is not clustered by
         // Iceberg partition value); round-robin is only needed when the
         // stream count differs.
-        let plan_to_execute: Arc<dyn ExecutionPlan + 'static> =
-            if matches!(&output_partitioning, Partitioning::Hash(_, _))
-                || physical_plan.output_partitioning().partition_count()
-                    != output_partitioning.partition_count()
-            {
-                Arc::new(RepartitionExec::try_new(
-                    physical_plan,
-                    output_partitioning,
-                )?)
-            } else {
-                physical_plan
-            };
+        let plan_to_execute = repartition_output_plan(physical_plan, output_partitioning)?;
 
         let schema = plan_to_execute.schema().clone();
 
@@ -235,64 +223,57 @@ impl DatafusionProcessor {
 
 /// Chooses how rows are distributed across the output writer streams.
 ///
-/// For a partitioned table whose input files span more than one partition,
-/// hash by the Iceberg partition value so every partition is written by
-/// exactly one stream. Each output stream owns a partition-aware fanout
-/// writer, so with round-robin distribution every stream sees every
-/// partition and the total number of open writers grows with
-/// `output streams x partitions` (and every partition's output is sliced
-/// into at least one file per stream). Hashing keeps the writer count at one
-/// per distinct partition in total and lets output parallelism stay at its
+/// For every partitioned table, hash by the complete Iceberg partition value
+/// so each partition is written by exactly one stream. Each output stream owns
+/// a partition-aware fanout writer, so with round-robin distribution every
+/// stream sees every partition and the total number of open writers grows with
+/// `output streams x partitions` (and every partition's output is sliced into
+/// at least one file per stream). Hashing keeps the writer count at one per
+/// distinct partition in total and lets output parallelism stay at its
 /// size-based value.
 ///
-/// Falls back to round-robin when:
-/// - the table is unpartitioned (no fanout at all), or
-/// - the input files cover at most one partition value (for example a
-///   partition-scoped file group): hashing would funnel all rows into a
-///   single stream, while round-robin lets every stream write to that one
-///   partition in parallel, or
-/// - the partition hash expression cannot be constructed.
+/// Unpartitioned tables keep round-robin distribution because they have no
+/// writer fan-out. A partition expression construction failure is returned to
+/// the caller rather than silently violating partition affinity.
 fn build_output_partitioning(
     datafusion_task_ctx: &DataFusionTaskContext,
     input_schema: &Schema,
     output_parallelism: usize,
-) -> Partitioning {
+) -> Result<Partitioning> {
     let round_robin = || Partitioning::RoundRobinBatch(output_parallelism);
 
     let Some(partition_spec) = &datafusion_task_ctx.partition_spec else {
-        return round_robin();
+        return Ok(round_robin());
     };
     if partition_spec.is_unpartitioned() || output_parallelism <= 1 {
-        return round_robin();
+        return Ok(round_robin());
     }
 
-    // Distinct partition values of the input files, from manifest metadata.
-    // Files written under an older partition spec approximate the current
-    // spec's fan-out here; this only gates the strategy and caps the stream
-    // count, so overcounting is harmless.
-    let distinct_partition_count = datafusion_task_ctx
-        .data_files
-        .iter()
-        .flatten()
-        .map(|task| task.partition.as_ref())
-        .collect::<HashSet<_>>()
-        .len();
-    if distinct_partition_count <= 1 {
-        return round_robin();
-    }
+    let expr =
+        IcebergPartitionExpr::try_new(Arc::new(input_schema.clone()), partition_spec.clone())?;
+    Ok(Partitioning::Hash(
+        vec![Arc::new(expr) as Arc<dyn PhysicalExpr>],
+        output_parallelism,
+    ))
+}
 
-    match IcebergPartitionExpr::try_new(Arc::new(input_schema.clone()), partition_spec.clone()) {
-        Ok(expr) => Partitioning::Hash(
-            vec![Arc::new(expr) as Arc<dyn PhysicalExpr>],
-            output_parallelism.min(distinct_partition_count),
-        ),
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                "failed to build Iceberg partition hash expression, falling back to round-robin output distribution"
-            );
-            round_robin()
-        }
+/// Installs the requested output distribution. Hash partitioning is always
+/// materialized because matching stream counts do not imply that the input is
+/// already clustered by Iceberg partition value.
+fn repartition_output_plan(
+    physical_plan: Arc<dyn ExecutionPlan>,
+    output_partitioning: Partitioning,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    if matches!(&output_partitioning, Partitioning::Hash(_, _))
+        || physical_plan.output_partitioning().partition_count()
+            != output_partitioning.partition_count()
+    {
+        Ok(Arc::new(RepartitionExec::try_new(
+            physical_plan,
+            output_partitioning,
+        )?))
+    } else {
+        Ok(physical_plan)
     }
 }
 
@@ -2228,36 +2209,34 @@ mod tests {
 
             let ctx = build_ctx(&schema, None, vec![None]);
             assert!(matches!(
-                build_output_partitioning(&ctx, &schema, 8),
+                build_output_partitioning(&ctx, &schema, 8).unwrap(),
                 Partitioning::RoundRobinBatch(8)
             ));
 
             let ctx = build_ctx(&schema, Some(unpartitioned_spec(&schema)), vec![None]);
             assert!(matches!(
-                build_output_partitioning(&ctx, &schema, 8),
+                build_output_partitioning(&ctx, &schema, 8).unwrap(),
                 Partitioning::RoundRobinBatch(8)
             ));
         }
 
-        /// A file group covering a single partition value (for example a
-        /// partition-scoped group) keeps round-robin so every stream can write
-        /// that one partition in parallel.
+        /// A single-partition group still hashes so its partition belongs to
+        /// exactly one output stream.
         #[test]
-        fn test_round_robin_for_single_partition_group() {
+        fn test_hash_for_single_partition_group() {
             let schema = partitioned_table_schema();
             let ctx = build_ctx(&schema, Some(identity_spec(&schema)), vec![
                 Some(partition_value(7)),
                 Some(partition_value(7)),
             ]);
             assert!(matches!(
-                build_output_partitioning(&ctx, &schema, 8),
-                Partitioning::RoundRobinBatch(8)
+                build_output_partitioning(&ctx, &schema, 8).unwrap(),
+                Partitioning::Hash(_, 8)
             ));
         }
 
         /// A partitioned table spanning multiple partitions hashes by the
-        /// Iceberg partition value, with the stream count capped by the
-        /// distinct partition count.
+        /// Iceberg partition value while preserving size-based parallelism.
         #[test]
         fn test_hash_for_multi_partition_group() {
             let schema = partitioned_table_schema();
@@ -2268,12 +2247,11 @@ mod tests {
             ];
 
             let ctx = build_ctx(&schema, Some(identity_spec(&schema)), partitions.clone());
-            let partitioning = build_output_partitioning(&ctx, &schema, 32);
+            let partitioning = build_output_partitioning(&ctx, &schema, 32).unwrap();
             match partitioning {
                 Partitioning::Hash(exprs, n) => {
                     assert_eq!(exprs.len(), 1);
-                    // Stream count capped by the distinct partition count.
-                    assert_eq!(n, 3);
+                    assert_eq!(n, 32);
                 }
                 other => panic!("expected hash partitioning, got {other:?}"),
             }
@@ -2282,7 +2260,7 @@ mod tests {
             // output parallelism.
             let ctx = build_ctx(&schema, Some(identity_spec(&schema)), partitions);
             assert!(matches!(
-                build_output_partitioning(&ctx, &schema, 2),
+                build_output_partitioning(&ctx, &schema, 2).unwrap(),
                 Partitioning::Hash(_, 2)
             ));
         }
@@ -2298,7 +2276,7 @@ mod tests {
             };
             use datafusion::arrow::record_batch::RecordBatch;
             use datafusion::datasource::MemTable;
-            use futures::StreamExt;
+            use datafusion::physical_plan::collect_partitioned;
 
             use crate::executor::datafusion::iceberg_partition_expr::IcebergPartitionExpr;
 
@@ -2311,19 +2289,28 @@ mod tests {
             ]));
             let total_rows = 1000;
             let distinct_partitions = 7;
-            let batch = RecordBatch::try_new(arrow_schema.clone(), vec![
-                Arc::new((0..total_rows).collect::<Int32Array>()),
-                Arc::new(
-                    (0..total_rows)
-                        .map(|i| i % distinct_partitions)
-                        .collect::<Int32Array>(),
-                ),
-            ])
-            .unwrap();
+            let input_partitions = (0..4)
+                .map(|input_partition| {
+                    let ids = (input_partition..total_rows)
+                        .step_by(4)
+                        .collect::<Int32Array>();
+                    let partition_values = ids
+                        .iter()
+                        .map(|id| id.map(|id| id % distinct_partitions))
+                        .collect::<Int32Array>();
+                    vec![
+                        RecordBatch::try_new(arrow_schema.clone(), vec![
+                            Arc::new(ids),
+                            Arc::new(partition_values),
+                        ])
+                        .unwrap(),
+                    ]
+                })
+                .collect();
 
             let ctx =
                 SessionContext::new_with_config(SessionConfig::new().with_target_partitions(4));
-            let table = MemTable::try_new(arrow_schema, vec![vec![batch]]).unwrap();
+            let table = MemTable::try_new(arrow_schema, input_partitions).unwrap();
             ctx.register_table("t", Arc::new(table)).unwrap();
             let plan = ctx
                 .sql("SELECT id, p FROM t")
@@ -2335,22 +2322,25 @@ mod tests {
 
             let expr = IcebergPartitionExpr::try_new(schema, spec).unwrap();
             let output_parallelism = 4;
-            let repartitioned = Arc::new(
-                RepartitionExec::try_new(
-                    plan,
-                    Partitioning::Hash(vec![Arc::new(expr)], output_parallelism),
-                )
-                .unwrap(),
+            assert_eq!(
+                plan.output_partitioning().partition_count(),
+                output_parallelism
             );
+            let repartitioned = repartition_output_plan(
+                plan,
+                Partitioning::Hash(vec![Arc::new(expr)], output_parallelism),
+            )
+            .unwrap();
 
-            let streams = execute_stream_partitioned(repartitioned, ctx.task_ctx()).unwrap();
-            assert_eq!(streams.len(), output_parallelism);
+            let output = collect_partitioned(repartitioned, ctx.task_ctx())
+                .await
+                .unwrap();
+            assert_eq!(output.len(), output_parallelism);
 
             let mut seen_rows = 0;
             let mut partition_to_stream = std::collections::HashMap::new();
-            for (stream_idx, mut stream) in streams.into_iter().enumerate() {
-                while let Some(batch) = stream.next().await {
-                    let batch = batch.unwrap();
+            for (stream_idx, batches) in output.into_iter().enumerate() {
+                for batch in batches {
                     seen_rows += batch.num_rows();
                     let p_column = batch
                         .column(1)

--- a/core/src/executor/datafusion/datafusion_processor.rs
+++ b/core/src/executor/datafusion/datafusion_processor.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use datafusion::arrow::compute::SortOptions;
@@ -254,15 +253,11 @@ fn build_output_partitioning(
         return Ok(round_robin);
     }
 
-    let data_files = datafusion_task_ctx.data_files.iter().flatten();
-    let all_files_use_current_spec = data_files.clone().all(|task| {
-        task.partition_spec.as_ref().map(|spec| spec.spec_id()) == Some(partition_spec.spec_id())
-    });
-    let distinct_partition_count = data_files
-        .map(|task| task.partition.as_ref())
-        .collect::<HashSet<_>>()
-        .len();
-    if all_files_use_current_spec && distinct_partition_count <= 1 {
+    let data_files = datafusion_task_ctx
+        .data_files
+        .as_deref()
+        .unwrap_or_default();
+    if can_use_round_robin_for_partitioned_group(data_files, partition_spec) {
         return Ok(round_robin);
     }
 
@@ -272,6 +267,29 @@ fn build_output_partitioning(
         vec![Arc::new(expr) as Arc<dyn PhysicalExpr>],
         output_parallelism,
     ))
+}
+
+/// Returns whether round-robin is safe for a partitioned input group.
+///
+/// Every input file must use the current partition spec and have the same
+/// partition value. Files using an older or unknown spec require hash
+/// repartitioning because one old partition may map to multiple current ones.
+fn can_use_round_robin_for_partitioned_group(
+    data_files: &[FileScanTask],
+    current_spec: &iceberg::spec::PartitionSpec,
+) -> bool {
+    let Some(first_file) = data_files.first() else {
+        return true;
+    };
+    let first_partition = first_file.partition.as_ref();
+
+    data_files.iter().all(|file| {
+        let uses_current_spec = file
+            .partition_spec
+            .as_deref()
+            .is_some_and(|spec| spec.spec_id() == current_spec.spec_id());
+        uses_current_spec && file.partition.as_ref() == first_partition
+    })
 }
 
 /// Installs the requested output distribution. Hash partitioning is always

--- a/core/src/executor/datafusion/datafusion_processor.rs
+++ b/core/src/executor/datafusion/datafusion_processor.rs
@@ -245,13 +245,13 @@ fn build_output_partitioning(
     input_schema: &Schema,
     output_parallelism: usize,
 ) -> Result<Partitioning> {
-    let round_robin = || Partitioning::RoundRobinBatch(output_parallelism);
+    let round_robin = Partitioning::RoundRobinBatch(output_parallelism);
 
     let Some(partition_spec) = &datafusion_task_ctx.partition_spec else {
-        return Ok(round_robin());
+        return Ok(round_robin);
     };
     if partition_spec.is_unpartitioned() || output_parallelism <= 1 {
-        return Ok(round_robin());
+        return Ok(round_robin);
     }
 
     let data_files = datafusion_task_ctx.data_files.iter().flatten();
@@ -263,7 +263,7 @@ fn build_output_partitioning(
         .collect::<HashSet<_>>()
         .len();
     if all_files_use_current_spec && distinct_partition_count <= 1 {
-        return Ok(round_robin());
+        return Ok(round_robin);
     }
 
     let expr =

--- a/core/src/executor/datafusion/datafusion_processor.rs
+++ b/core/src/executor/datafusion/datafusion_processor.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use datafusion::arrow::compute::SortOptions;
@@ -21,8 +22,8 @@ use datafusion::execution::SendableRecordBatchStream;
 use datafusion::execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
 use datafusion::execution::memory_pool::{FairSpillPool, MemoryPool};
 use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
-use datafusion::physical_expr::PhysicalSortExpr;
 use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::{PhysicalExpr, PhysicalSortExpr};
 use datafusion::physical_expr_common::sort_expr::LexOrdering;
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::sorts::sort::SortExec;
@@ -34,11 +35,12 @@ use iceberg::arrow::schema_to_arrow_schema;
 use iceberg::io::FileIO;
 use iceberg::scan::FileScanTask;
 use iceberg::spec::{
-    DataContentType, FormatVersion, NestedField, PrimitiveType, Schema, SortOrderRef, Transform,
-    Type,
+    DataContentType, FormatVersion, NestedField, PartitionSpecRef, PrimitiveType, Schema,
+    SortOrderRef, Transform, Type,
 };
 
 use super::file_scan_task_table_provider::IcebergFileScanTaskTableProvider;
+use super::iceberg_partition_expr::IcebergPartitionExpr;
 use crate::config::CompactionExecutionConfig;
 use crate::error::{CompactionError, Result};
 use crate::executor::TableSortOrder;
@@ -174,17 +176,28 @@ impl DatafusionProcessor {
         let exec_sql = datafusion_task_ctx.exec_sql.clone();
 
         let sort_order = datafusion_task_ctx.sort_order.clone();
+        // Decide the output distribution before table registration consumes
+        // the data file scan tasks.
+        let output_partitioning =
+            build_output_partitioning(&datafusion_task_ctx, &input_schema, output_parallelism);
         self.register_tables(datafusion_task_ctx)?;
 
         let df = self.ctx.sql(&exec_sql).await?;
         let physical_plan = df.create_physical_plan().await?;
 
-        // Conditionally create a new physical_plan if repartitioning is needed
+        // Repartition so the plan produces exactly the output streams the
+        // writers expect. Hash distribution must always go through a
+        // `RepartitionExec` (the scan's own partitioning is not clustered by
+        // Iceberg partition value); round-robin is only needed when the
+        // stream count differs.
         let plan_to_execute: Arc<dyn ExecutionPlan + 'static> =
-            if physical_plan.output_partitioning().partition_count() != output_parallelism {
+            if matches!(&output_partitioning, Partitioning::Hash(_, _))
+                || physical_plan.output_partitioning().partition_count()
+                    != output_partitioning.partition_count()
+            {
                 Arc::new(RepartitionExec::try_new(
                     physical_plan,
-                    Partitioning::RoundRobinBatch(output_parallelism),
+                    output_partitioning,
                 )?)
             } else {
                 physical_plan
@@ -217,6 +230,69 @@ impl DatafusionProcessor {
         // Use execute_stream_partitioned to execute all partitions at once
         let batches = execute_stream_partitioned(plan_to_execute, self.ctx.task_ctx())?;
         Ok((batches, input_schema))
+    }
+}
+
+/// Chooses how rows are distributed across the output writer streams.
+///
+/// For a partitioned table whose input files span more than one partition,
+/// hash by the Iceberg partition value so every partition is written by
+/// exactly one stream. Each output stream owns a partition-aware fanout
+/// writer, so with round-robin distribution every stream sees every
+/// partition and the total number of open writers grows with
+/// `output streams x partitions` (and every partition's output is sliced
+/// into at least one file per stream). Hashing keeps the writer count at one
+/// per distinct partition in total and lets output parallelism stay at its
+/// size-based value.
+///
+/// Falls back to round-robin when:
+/// - the table is unpartitioned (no fanout at all), or
+/// - the input files cover at most one partition value (for example a
+///   partition-scoped file group): hashing would funnel all rows into a
+///   single stream, while round-robin lets every stream write to that one
+///   partition in parallel, or
+/// - the partition hash expression cannot be constructed.
+fn build_output_partitioning(
+    datafusion_task_ctx: &DataFusionTaskContext,
+    input_schema: &Schema,
+    output_parallelism: usize,
+) -> Partitioning {
+    let round_robin = || Partitioning::RoundRobinBatch(output_parallelism);
+
+    let Some(partition_spec) = &datafusion_task_ctx.partition_spec else {
+        return round_robin();
+    };
+    if partition_spec.is_unpartitioned() || output_parallelism <= 1 {
+        return round_robin();
+    }
+
+    // Distinct partition values of the input files, from manifest metadata.
+    // Files written under an older partition spec approximate the current
+    // spec's fan-out here; this only gates the strategy and caps the stream
+    // count, so overcounting is harmless.
+    let distinct_partition_count = datafusion_task_ctx
+        .data_files
+        .iter()
+        .flatten()
+        .map(|task| task.partition.as_ref())
+        .collect::<HashSet<_>>()
+        .len();
+    if distinct_partition_count <= 1 {
+        return round_robin();
+    }
+
+    match IcebergPartitionExpr::try_new(Arc::new(input_schema.clone()), partition_spec.clone()) {
+        Ok(expr) => Partitioning::Hash(
+            vec![Arc::new(expr) as Arc<dyn PhysicalExpr>],
+            output_parallelism.min(distinct_partition_count),
+        ),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "failed to build Iceberg partition hash expression, falling back to round-robin output distribution"
+            );
+            round_robin()
+        }
     }
 }
 
@@ -609,6 +685,7 @@ pub struct DataFusionTaskContext {
     pub(crate) exec_sql: String,
     pub(crate) table_prefix: String,
     pub(crate) sort_order: Option<TableSortOrder>,
+    pub(crate) partition_spec: Option<PartitionSpecRef>,
 }
 
 pub struct DataFusionTaskContextBuilder {
@@ -619,6 +696,7 @@ pub struct DataFusionTaskContextBuilder {
     table_prefix: String,
     sort_order: Option<TableSortOrder>,
     format_version: FormatVersion,
+    partition_spec: Option<PartitionSpecRef>,
 }
 
 impl DataFusionTaskContextBuilder {
@@ -639,6 +717,13 @@ impl DataFusionTaskContextBuilder {
 
     pub fn with_format_version(mut self, format_version: FormatVersion) -> Self {
         self.format_version = format_version;
+        self
+    }
+
+    /// Sets the table's default partition spec, enabling partition-value hash
+    /// distribution of output streams for partitioned tables.
+    pub fn with_partition_spec(mut self, partition_spec: PartitionSpecRef) -> Self {
+        self.partition_spec = Some(partition_spec);
         self
     }
 
@@ -833,6 +918,7 @@ impl DataFusionTaskContextBuilder {
             exec_sql,
             table_prefix: self.table_prefix,
             sort_order: self.sort_order,
+            partition_spec: self.partition_spec,
         })
     }
 
@@ -879,6 +965,7 @@ impl DataFusionTaskContext {
             table_prefix: "".to_owned(),
             sort_order: None,
             format_version: FormatVersion::V2,
+            partition_spec: None,
         })
     }
 
@@ -1375,6 +1462,7 @@ mod tests {
             table_prefix: "".to_owned(),
             sort_order: None,
             format_version: FormatVersion::V2,
+            partition_spec: None,
         };
 
         let equality_ids = vec![1, 2];
@@ -2036,6 +2124,254 @@ mod tests {
         for (input, expected) in quoted_identifiers {
             let result = quote_identifier(input);
             assert_eq!(result, expected);
+        }
+    }
+
+    mod output_partitioning {
+        use iceberg::spec::{Literal, PartitionSpec, PartitionSpecRef, PrimitiveLiteral, Struct};
+
+        use super::*;
+
+        fn partitioned_table_schema() -> Arc<Schema> {
+            Arc::new(
+                Schema::builder()
+                    .with_schema_id(1)
+                    .with_fields(vec![
+                        Arc::new(NestedField::required(
+                            1,
+                            "id",
+                            Type::Primitive(PrimitiveType::Int),
+                        )),
+                        Arc::new(NestedField::required(
+                            2,
+                            "p",
+                            Type::Primitive(PrimitiveType::Int),
+                        )),
+                    ])
+                    .build()
+                    .unwrap(),
+            )
+        }
+
+        fn identity_spec(schema: &Schema) -> PartitionSpecRef {
+            Arc::new(
+                PartitionSpec::builder(schema.clone())
+                    .with_spec_id(1)
+                    .add_partition_field("p", "p", Transform::Identity)
+                    .unwrap()
+                    .build()
+                    .unwrap(),
+            )
+        }
+
+        fn unpartitioned_spec(schema: &Schema) -> PartitionSpecRef {
+            Arc::new(
+                PartitionSpec::builder(schema.clone())
+                    .with_spec_id(0)
+                    .build()
+                    .unwrap(),
+            )
+        }
+
+        fn partition_value(value: i32) -> Struct {
+            Struct::from_iter(vec![Some(Literal::Primitive(PrimitiveLiteral::Int(value)))])
+        }
+
+        fn data_file_task(schema: &Arc<Schema>, partition: Option<Struct>) -> FileScanTask {
+            FileScanTask {
+                length: 1024,
+                start: 0,
+                record_count: Some(1),
+                first_row_id: None,
+                data_sequence_number: None,
+                data_file_path: "test.parquet".to_owned(),
+                data_file_format: iceberg::spec::DataFileFormat::Parquet,
+                schema: schema.clone(),
+                project_field_ids: vec![],
+                predicate: None,
+                deletes: vec![],
+                sequence_number: 0,
+                file_size_in_bytes: 1024,
+                partition,
+                partition_spec: None,
+                name_mapping: None,
+                unified_partition_type: None,
+                case_sensitive: true,
+                key_metadata: None,
+            }
+        }
+
+        fn build_ctx(
+            schema: &Arc<Schema>,
+            partition_spec: Option<PartitionSpecRef>,
+            partitions: Vec<Option<Struct>>,
+        ) -> DataFusionTaskContext {
+            let data_files = partitions
+                .into_iter()
+                .map(|p| data_file_task(schema, p))
+                .collect();
+            let mut builder = DataFusionTaskContext::builder()
+                .unwrap()
+                .with_schema(schema.clone())
+                .with_data_files(data_files);
+            if let Some(spec) = partition_spec {
+                builder = builder.with_partition_spec(spec);
+            }
+            builder.build().unwrap()
+        }
+
+        /// Without a partition spec (or with an unpartitioned one) the output
+        /// stays round-robin distributed.
+        #[test]
+        fn test_round_robin_without_partitioning() {
+            let schema = partitioned_table_schema();
+
+            let ctx = build_ctx(&schema, None, vec![None]);
+            assert!(matches!(
+                build_output_partitioning(&ctx, &schema, 8),
+                Partitioning::RoundRobinBatch(8)
+            ));
+
+            let ctx = build_ctx(&schema, Some(unpartitioned_spec(&schema)), vec![None]);
+            assert!(matches!(
+                build_output_partitioning(&ctx, &schema, 8),
+                Partitioning::RoundRobinBatch(8)
+            ));
+        }
+
+        /// A file group covering a single partition value (for example a
+        /// partition-scoped group) keeps round-robin so every stream can write
+        /// that one partition in parallel.
+        #[test]
+        fn test_round_robin_for_single_partition_group() {
+            let schema = partitioned_table_schema();
+            let ctx = build_ctx(&schema, Some(identity_spec(&schema)), vec![
+                Some(partition_value(7)),
+                Some(partition_value(7)),
+            ]);
+            assert!(matches!(
+                build_output_partitioning(&ctx, &schema, 8),
+                Partitioning::RoundRobinBatch(8)
+            ));
+        }
+
+        /// A partitioned table spanning multiple partitions hashes by the
+        /// Iceberg partition value, with the stream count capped by the
+        /// distinct partition count.
+        #[test]
+        fn test_hash_for_multi_partition_group() {
+            let schema = partitioned_table_schema();
+            let partitions = vec![
+                Some(partition_value(1)),
+                Some(partition_value(2)),
+                Some(partition_value(3)),
+            ];
+
+            let ctx = build_ctx(&schema, Some(identity_spec(&schema)), partitions.clone());
+            let partitioning = build_output_partitioning(&ctx, &schema, 32);
+            match partitioning {
+                Partitioning::Hash(exprs, n) => {
+                    assert_eq!(exprs.len(), 1);
+                    // Stream count capped by the distinct partition count.
+                    assert_eq!(n, 3);
+                }
+                other => panic!("expected hash partitioning, got {other:?}"),
+            }
+
+            // More partitions than output parallelism: keep the size-based
+            // output parallelism.
+            let ctx = build_ctx(&schema, Some(identity_spec(&schema)), partitions);
+            assert!(matches!(
+                build_output_partitioning(&ctx, &schema, 2),
+                Partitioning::Hash(_, 2)
+            ));
+        }
+
+        /// End-to-end: repartitioning by `IcebergPartitionExpr` routes every
+        /// distinct partition value to exactly one output stream and preserves
+        /// all rows.
+        #[tokio::test]
+        async fn test_hash_repartition_routes_each_partition_to_one_stream() {
+            use datafusion::arrow::array::Int32Array;
+            use datafusion::arrow::datatypes::{
+                DataType as ArrowDataType, Field, Schema as ArrowSchema,
+            };
+            use datafusion::arrow::record_batch::RecordBatch;
+            use datafusion::datasource::MemTable;
+            use futures::StreamExt;
+
+            use crate::executor::datafusion::iceberg_partition_expr::IcebergPartitionExpr;
+
+            let schema = partitioned_table_schema();
+            let spec = identity_spec(&schema);
+
+            let arrow_schema = Arc::new(ArrowSchema::new(vec![
+                Field::new("id", ArrowDataType::Int32, false),
+                Field::new("p", ArrowDataType::Int32, false),
+            ]));
+            let total_rows = 1000;
+            let distinct_partitions = 7;
+            let batch = RecordBatch::try_new(arrow_schema.clone(), vec![
+                Arc::new((0..total_rows).collect::<Int32Array>()),
+                Arc::new(
+                    (0..total_rows)
+                        .map(|i| i % distinct_partitions)
+                        .collect::<Int32Array>(),
+                ),
+            ])
+            .unwrap();
+
+            let ctx =
+                SessionContext::new_with_config(SessionConfig::new().with_target_partitions(4));
+            let table = MemTable::try_new(arrow_schema, vec![vec![batch]]).unwrap();
+            ctx.register_table("t", Arc::new(table)).unwrap();
+            let plan = ctx
+                .sql("SELECT id, p FROM t")
+                .await
+                .unwrap()
+                .create_physical_plan()
+                .await
+                .unwrap();
+
+            let expr = IcebergPartitionExpr::try_new(schema, spec).unwrap();
+            let output_parallelism = 4;
+            let repartitioned = Arc::new(
+                RepartitionExec::try_new(
+                    plan,
+                    Partitioning::Hash(vec![Arc::new(expr)], output_parallelism),
+                )
+                .unwrap(),
+            );
+
+            let streams = execute_stream_partitioned(repartitioned, ctx.task_ctx()).unwrap();
+            assert_eq!(streams.len(), output_parallelism);
+
+            let mut seen_rows = 0;
+            let mut partition_to_stream = std::collections::HashMap::new();
+            for (stream_idx, mut stream) in streams.into_iter().enumerate() {
+                while let Some(batch) = stream.next().await {
+                    let batch = batch.unwrap();
+                    seen_rows += batch.num_rows();
+                    let p_column = batch
+                        .column(1)
+                        .as_any()
+                        .downcast_ref::<Int32Array>()
+                        .unwrap();
+                    for i in 0..batch.num_rows() {
+                        let assigned = partition_to_stream
+                            .entry(p_column.value(i))
+                            .or_insert(stream_idx);
+                        assert_eq!(
+                            *assigned,
+                            stream_idx,
+                            "partition {} appeared in more than one output stream",
+                            p_column.value(i)
+                        );
+                    }
+                }
+            }
+            assert_eq!(seen_rows, total_rows as usize);
+            assert_eq!(partition_to_stream.len(), distinct_partitions as usize);
         }
     }
 }

--- a/core/src/executor/datafusion/datafusion_processor.rs
+++ b/core/src/executor/datafusion/datafusion_processor.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use datafusion::arrow::compute::SortOptions;
@@ -223,18 +224,22 @@ impl DatafusionProcessor {
 
 /// Chooses how rows are distributed across the output writer streams.
 ///
-/// For every partitioned table, hash by the complete Iceberg partition value
-/// so each partition is written by exactly one stream. Each output stream owns
-/// a partition-aware fanout writer, so with round-robin distribution every
-/// stream sees every partition and the total number of open writers grows with
-/// `output streams x partitions` (and every partition's output is sliced into
-/// at least one file per stream). Hashing keeps the writer count at one per
-/// distinct partition in total and lets output parallelism stay at its
-/// size-based value.
+/// For partitioned tables spanning multiple partitions, hash by the complete
+/// Iceberg partition value so each partition is written by exactly one stream.
+/// Each output stream owns a partition-aware fanout writer, so with round-robin
+/// distribution every stream sees every partition and the total number of open
+/// writers grows with `output streams x partitions` (and every partition's
+/// output is sliced into at least one file per stream). Hashing keeps the writer
+/// count at one per distinct partition in total and lets output parallelism stay
+/// at its size-based value.
 ///
-/// Unpartitioned tables keep round-robin distribution because they have no
-/// writer fan-out. A partition expression construction failure is returned to
-/// the caller rather than silently violating partition affinity.
+/// Unpartitioned tables and single-partition groups keep round-robin
+/// distribution so they can use all output streams without unbounded writer
+/// fan-out. The latter optimization is only safe when every input file uses the
+/// current partition spec; an older spec's single manifest partition value may
+/// fan out into multiple values under the current spec. A partition expression
+/// construction failure is returned to the caller rather than silently
+/// violating partition affinity.
 fn build_output_partitioning(
     datafusion_task_ctx: &DataFusionTaskContext,
     input_schema: &Schema,
@@ -246,6 +251,18 @@ fn build_output_partitioning(
         return Ok(round_robin());
     };
     if partition_spec.is_unpartitioned() || output_parallelism <= 1 {
+        return Ok(round_robin());
+    }
+
+    let data_files = datafusion_task_ctx.data_files.iter().flatten();
+    let all_files_use_current_spec = data_files.clone().all(|task| {
+        task.partition_spec.as_ref().map(|spec| spec.spec_id()) == Some(partition_spec.spec_id())
+    });
+    let distinct_partition_count = data_files
+        .map(|task| task.partition.as_ref())
+        .collect::<HashSet<_>>()
+        .len();
+    if all_files_use_current_spec && distinct_partition_count <= 1 {
         return Ok(round_robin());
     }
 
@@ -2134,15 +2151,19 @@ mod tests {
             )
         }
 
-        fn identity_spec(schema: &Schema) -> PartitionSpecRef {
+        fn identity_spec_with_id(schema: &Schema, spec_id: i32) -> PartitionSpecRef {
             Arc::new(
                 PartitionSpec::builder(schema.clone())
-                    .with_spec_id(1)
+                    .with_spec_id(spec_id)
                     .add_partition_field("p", "p", Transform::Identity)
                     .unwrap()
                     .build()
                     .unwrap(),
             )
+        }
+
+        fn identity_spec(schema: &Schema) -> PartitionSpecRef {
+            identity_spec_with_id(schema, 1)
         }
 
         fn unpartitioned_spec(schema: &Schema) -> PartitionSpecRef {
@@ -2158,7 +2179,11 @@ mod tests {
             Struct::from_iter(vec![Some(Literal::Primitive(PrimitiveLiteral::Int(value)))])
         }
 
-        fn data_file_task(schema: &Arc<Schema>, partition: Option<Struct>) -> FileScanTask {
+        fn data_file_task(
+            schema: &Arc<Schema>,
+            partition: Option<Struct>,
+            partition_spec: Option<PartitionSpecRef>,
+        ) -> FileScanTask {
             FileScanTask {
                 length: 1024,
                 start: 0,
@@ -2174,7 +2199,7 @@ mod tests {
                 sequence_number: 0,
                 file_size_in_bytes: 1024,
                 partition,
-                partition_spec: None,
+                partition_spec,
                 name_mapping: None,
                 unified_partition_type: None,
                 case_sensitive: true,
@@ -2189,7 +2214,7 @@ mod tests {
         ) -> DataFusionTaskContext {
             let data_files = partitions
                 .into_iter()
-                .map(|p| data_file_task(schema, p))
+                .map(|p| data_file_task(schema, p, partition_spec.clone()))
                 .collect();
             let mut builder = DataFusionTaskContext::builder()
                 .unwrap()
@@ -2220,15 +2245,27 @@ mod tests {
             ));
         }
 
-        /// A single-partition group still hashes so its partition belongs to
-        /// exactly one output stream.
+        /// A single-partition group written under the current spec keeps
+        /// round-robin so all output streams can write it in parallel. If an
+        /// input file uses an older spec, hash because that one manifest value
+        /// may fan out under the current spec.
         #[test]
-        fn test_hash_for_single_partition_group() {
+        fn test_single_partition_group_respects_spec_evolution() {
             let schema = partitioned_table_schema();
-            let ctx = build_ctx(&schema, Some(identity_spec(&schema)), vec![
+            let current_spec = identity_spec(&schema);
+            let ctx = build_ctx(&schema, Some(current_spec.clone()), vec![
                 Some(partition_value(7)),
                 Some(partition_value(7)),
             ]);
+            assert!(matches!(
+                build_output_partitioning(&ctx, &schema, 8).unwrap(),
+                Partitioning::RoundRobinBatch(8)
+            ));
+
+            let mut ctx = ctx;
+            for task in ctx.data_files.as_mut().unwrap() {
+                task.partition_spec = Some(identity_spec_with_id(&schema, 0));
+            }
             assert!(matches!(
                 build_output_partitioning(&ctx, &schema, 8).unwrap(),
                 Partitioning::Hash(_, 8)

--- a/core/src/executor/datafusion/iceberg_partition_expr.rs
+++ b/core/src/executor/datafusion/iceberg_partition_expr.rs
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2025 iceberg-compaction
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::fmt::{self, Display, Formatter};
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::{DataType, Schema as ArrowSchema};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_plan::ColumnarValue;
+use iceberg::arrow::PartitionValueCalculator;
+use iceberg::spec::{PartitionSpecRef, SchemaRef as IcebergSchemaRef};
+
+use crate::error::Result;
+
+/// Physical expression evaluating to the Iceberg partition value (the struct
+/// of transformed partition fields under the given partition spec) for each
+/// input row.
+///
+/// It is used as the hash key of a `RepartitionExec` so that all rows
+/// belonging to one Iceberg partition are routed to exactly one output
+/// stream. Compared to round-robin distribution, this keeps the number of
+/// open fanout writers at one per distinct partition in total (instead of
+/// `output streams x partitions`) and avoids slicing every partition's output
+/// into one file per stream.
+pub struct IcebergPartitionExpr {
+    table_schema: IcebergSchemaRef,
+    partition_spec: PartitionSpecRef,
+    calculator: PartitionValueCalculator,
+    partition_arrow_type: DataType,
+}
+
+impl IcebergPartitionExpr {
+    /// Creates an expression computing partition values of `partition_spec`
+    /// over batches whose layout matches `table_schema`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the spec is unpartitioned or a partition transform
+    /// or source column projection cannot be constructed.
+    pub fn try_new(
+        table_schema: IcebergSchemaRef,
+        partition_spec: PartitionSpecRef,
+    ) -> Result<Self> {
+        let calculator = PartitionValueCalculator::try_new(&partition_spec, &table_schema)?;
+        let partition_arrow_type = calculator.partition_arrow_type().clone();
+        Ok(Self {
+            table_schema,
+            partition_spec,
+            calculator,
+            partition_arrow_type,
+        })
+    }
+}
+
+impl PhysicalExpr for IcebergPartitionExpr {
+    fn data_type(&self, _input_schema: &ArrowSchema) -> DFResult<DataType> {
+        Ok(self.partition_arrow_type.clone())
+    }
+
+    fn nullable(&self, _input_schema: &ArrowSchema) -> DFResult<bool> {
+        // Every row has a partition value struct; individual partition fields
+        // may be null inside the struct.
+        Ok(false)
+    }
+
+    fn evaluate(&self, batch: &RecordBatch) -> DFResult<ColumnarValue> {
+        let array = self
+            .calculator
+            .calculate(batch)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        Ok(ColumnarValue::Array(array))
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> DFResult<Arc<dyn PhysicalExpr>> {
+        Ok(self)
+    }
+
+    fn fmt_sql(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "iceberg_partition_value(spec_id={})",
+            self.partition_spec.spec_id()
+        )
+    }
+}
+
+impl Display for IcebergPartitionExpr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "IcebergPartitionExpr(spec_id={})",
+            self.partition_spec.spec_id()
+        )
+    }
+}
+
+impl fmt::Debug for IcebergPartitionExpr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IcebergPartitionExpr")
+            .field("partition_spec", &self.partition_spec)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for IcebergPartitionExpr {
+    fn eq(&self, other: &Self) -> bool {
+        self.partition_spec == other.partition_spec
+            && self.table_schema.as_ref() == other.table_schema.as_ref()
+    }
+}
+
+impl Eq for IcebergPartitionExpr {}
+
+impl Hash for IcebergPartitionExpr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.partition_spec.spec_id().hash(state);
+        self.table_schema.schema_id().hash(state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::array::{Array, Int32Array, StringArray, StructArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+    use iceberg::spec::{NestedField, PartitionSpec, PrimitiveType, Schema, Transform, Type};
+
+    use super::*;
+
+    fn table_schema() -> IcebergSchemaRef {
+        Arc::new(
+            Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    Arc::new(NestedField::required(
+                        1,
+                        "id",
+                        Type::Primitive(PrimitiveType::Int),
+                    )),
+                    Arc::new(NestedField::required(
+                        2,
+                        "category",
+                        Type::Primitive(PrimitiveType::String),
+                    )),
+                ])
+                .build()
+                .unwrap(),
+        )
+    }
+
+    fn identity_bucket_spec(schema: &Schema) -> PartitionSpecRef {
+        Arc::new(
+            PartitionSpec::builder(schema.clone())
+                .with_spec_id(1)
+                .add_partition_field("category", "category", Transform::Identity)
+                .unwrap()
+                .add_partition_field("id", "id_bucket", Transform::Bucket(4))
+                .unwrap()
+                .build()
+                .unwrap(),
+        )
+    }
+
+    fn test_batch() -> RecordBatch {
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("category", DataType::Utf8, false),
+        ]));
+        RecordBatch::try_new(arrow_schema, vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+            Arc::new(StringArray::from(vec!["a", "b", "a", "b"])),
+        ])
+        .unwrap()
+    }
+
+    /// The expression evaluates to a struct of transformed partition values:
+    /// identity keeps the source value, bucket maps equal inputs to equal
+    /// bucket ids. Rows with equal partition values must produce equal structs
+    /// (that is what the hash repartitioning keys on).
+    #[test]
+    fn test_evaluate_partition_values() {
+        let schema = table_schema();
+        let spec = identity_bucket_spec(&schema);
+        let expr = IcebergPartitionExpr::try_new(schema, spec).unwrap();
+
+        let batch = test_batch();
+        assert_eq!(
+            expr.data_type(&batch.schema()).unwrap(),
+            expr.partition_arrow_type
+        );
+
+        let ColumnarValue::Array(array) = expr.evaluate(&batch).unwrap() else {
+            panic!("expected array result");
+        };
+        let struct_array = array.as_any().downcast_ref::<StructArray>().unwrap();
+        assert_eq!(struct_array.len(), 4);
+        assert_eq!(struct_array.num_columns(), 2);
+
+        let categories = struct_array
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(categories.value(0), "a");
+        assert_eq!(categories.value(1), "b");
+
+        let buckets = struct_array
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        for i in 0..4 {
+            let bucket = buckets.value(i);
+            assert!((0..4).contains(&bucket), "bucket id out of range: {bucket}");
+        }
+    }
+
+    /// Unpartitioned specs cannot be used as a repartitioning key.
+    #[test]
+    fn test_unpartitioned_spec_rejected() {
+        let schema = table_schema();
+        let spec = Arc::new(
+            PartitionSpec::builder(schema.as_ref().clone())
+                .with_spec_id(0)
+                .build()
+                .unwrap(),
+        );
+        assert!(IcebergPartitionExpr::try_new(schema, spec).is_err());
+    }
+
+    /// Equality and hash identify the expression by (schema, partition spec),
+    /// as required by `DynEq`/`DynHash` for plan comparison.
+    #[test]
+    fn test_eq_by_schema_and_spec() {
+        let schema = table_schema();
+        let spec = identity_bucket_spec(&schema);
+        let a = IcebergPartitionExpr::try_new(schema.clone(), spec.clone()).unwrap();
+        let b = IcebergPartitionExpr::try_new(schema.clone(), spec).unwrap();
+        assert_eq!(a, b);
+
+        let other_spec = Arc::new(
+            PartitionSpec::builder(schema.as_ref().clone())
+                .with_spec_id(2)
+                .add_partition_field("id", "id", Transform::Identity)
+                .unwrap()
+                .build()
+                .unwrap(),
+        );
+        let c = IcebergPartitionExpr::try_new(schema, other_spec).unwrap();
+        assert_ne!(a, c);
+    }
+}

--- a/core/src/executor/datafusion/mod.rs
+++ b/core/src/executor/datafusion/mod.rs
@@ -42,6 +42,7 @@ pub mod datafusion_processor;
 use super::{RewriteFilesRequest, RewriteFilesResponse};
 pub mod file_scan_task_table_provider;
 pub mod iceberg_file_task_scan;
+pub mod iceberg_partition_expr;
 
 #[derive(Debug, Default)]
 pub struct DataFusionExecutor {}
@@ -73,6 +74,7 @@ impl CompactionExecutor for DataFusionExecutor {
             .with_format_version(format_version)
             .with_input_data_files(file_group)
             .with_sort_order(sort_order.clone())
+            .with_partition_spec(partition_spec.clone())
             .build()?;
         let (batches, input_schema) = DatafusionProcessor::new(
             execution_config.clone(),


### PR DESCRIPTION
## Problem

For a partitioned table, compaction output rows are currently distributed to writer streams with `RoundRobinBatch`. Each stream owns a partition-aware fanout writer, so every stream can see every partition. Open writers therefore grow as `output_parallelism × distinct partitions`, and each partition's compacted output can be fragmented across the streams.

Reducing output parallelism by the partition count only trades throughput for memory: it approaches a single stream for high-partition-count tables while the remaining writer count still grows with the partition count.

## Change

Hash-repartition partitioned-table output by the complete transformed Iceberg partition value before sorting and writing:

- `IcebergPartitionExpr` evaluates the partition-value struct with iceberg-rust's `PartitionValueCalculator`, the same component used by the writer-side partition splitter. This keeps routing and writing consistent across all transforms and nested source columns.
- Every partitioned group uses `Partitioning::Hash([IcebergPartitionExpr], output_parallelism)`, including single-partition groups. The hash exchange is always materialized even when the input and requested output stream counts match.
- Unpartitioned tables retain round-robin distribution. Failure to construct the partition expression fails the operation instead of silently violating partition affinity.

This assigns each Iceberg partition to exactly one output stream, reducing total fanout writers from `output_parallelism × partitions` to `partitions` and avoiding per-stream file fragmentation. Output parallelism remains governed by the existing size-based calculation; no partition-count damping is needed.

## Semantics

The exchange remains before `SortExec` with partition preservation, so each output file retains the table's configured sort order. A single hot partition is intentionally handled by one stream; that is the inherent throughput tradeoff of strict partition affinity.

This supersedes #181.
