### PR TITLE
chore: bump iceberg-rust revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2305,7 +2305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2840,7 +2840,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=631180827ceb8d6296644edb9c5c8c29f770da5e#631180827ceb8d6296644edb9c5c8c29f770da5e"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=631180827ceb8d6296644edb9c5c8c29f770da5e#631180827ceb8d6296644edb9c5c8c29f770da5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=631180827ceb8d6296644edb9c5c8c29f770da5e#631180827ceb8d6296644edb9c5c8c29f770da5e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=631180827ceb8d6296644edb9c5c8c29f770da5e#631180827ceb8d6296644edb9c5c8c29f770da5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=2768ccf8b1847a14162337d7ef7a76935881fbc8#2768ccf8b1847a14162337d7ef7a76935881fbc8"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=631180827ceb8d6296644edb9c5c8c29f770da5e#631180827ceb8d6296644edb9c5c8c29f770da5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3649,7 +3649,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4230,7 +4230,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -4268,7 +4268,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4601,7 +4601,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4659,7 +4659,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5010,22 +5010,12 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5155,7 +5145,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5274,7 +5264,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5793,7 +5783,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ datafusion = "54.1"
 # Local workspace members
 futures = "0.3.17"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "631180827ceb8d6296644edb9c5c8c29f770da5e" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "631180827ceb8d6296644edb9c5c8c29f770da5e" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "631180827ceb8d6296644edb9c5c8c29f770da5e" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "631180827ceb8d6296644edb9c5c8c29f770da5e" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "2768ccf8b1847a14162337d7ef7a76935881fbc8", features = [
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "631180827ceb8d6296644edb9c5c8c29f770da5e" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "631180827ceb8d6296644edb9c5c8c29f770da5e", features = [
     "opendal-s3",
 ] }
 


### PR DESCRIPTION
Align all iceberg-rust workspace dependencies with the current `dev_rebase_main_20260807` head (`631180827ceb8d6296644edb9c5c8c29f770da5e`).

This keeps the Iceberg types exposed by iceberg-compaction identical to those used by direct consumers, unblocking RisingWave from updating both dependencies together. The lockfile is regenerated against the aligned revision.