### PR TITLE
chore: bump iceberg-rust for OpenDAL metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c#cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=3e5807d2caca586be5a670296781ad2dff1afdc5#3e5807d2caca586be5a670296781ad2dff1afdc5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c#cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=3e5807d2caca586be5a670296781ad2dff1afdc5#3e5807d2caca586be5a670296781ad2dff1afdc5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c#cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=3e5807d2caca586be5a670296781ad2dff1afdc5#3e5807d2caca586be5a670296781ad2dff1afdc5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c#cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=3e5807d2caca586be5a670296781ad2dff1afdc5#3e5807d2caca586be5a670296781ad2dff1afdc5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c#cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=3e5807d2caca586be5a670296781ad2dff1afdc5#3e5807d2caca586be5a670296781ad2dff1afdc5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ datafusion = "54.1"
 # Local workspace members
 futures = "0.3.17"
 # branch dev_rebase_main_20260807
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c" }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c" }
-iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c" }
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "3e5807d2caca586be5a670296781ad2dff1afdc5" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "3e5807d2caca586be5a670296781ad2dff1afdc5" }
+iceberg-catalog-memory = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "3e5807d2caca586be5a670296781ad2dff1afdc5" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "3e5807d2caca586be5a670296781ad2dff1afdc5" }
 iceberg-compaction-core = { path = "./core" }
-iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c" }
-iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "cd6e1e6acbfb2e41c9af5b6faedaca5eb83f361c", features = [
+iceberg-datafusion = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "3e5807d2caca586be5a670296781ad2dff1afdc5" }
+iceberg-storage-opendal = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "3e5807d2caca586be5a670296781ad2dff1afdc5", features = [
     "opendal-s3",
 ] }
 


### PR DESCRIPTION
## Summary

Update every iceberg-rust workspace dependency, including `iceberg-storage-opendal`, to the revision that exposes optional OpenDAL Prometheus metrics.

This is intentionally a dependency-only change. The compaction core continues to use the table's existing `FileIO`; keeping all Iceberg crates on one revision preserves Rust type identity for the downstream RisingWave integration.

Depends on risingwavelabs/iceberg-rust#232.

## Validation

- `cargo check -p iceberg-compaction-core`
- `make check`
